### PR TITLE
Fixed problems with item tasks

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/ItemTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/ItemTaskWidget.java
@@ -83,10 +83,10 @@ public final class ItemTaskWidget implements DisplayWidget {
             int buttonY = getHeight(width) - 19;
             boolean buttonHovered = mouseX > width - 2 - font.width(ConstantComponents.Tasks.CHECK) && mouseX < width - 2 && mouseY > buttonY && mouseY < buttonY + font.lineHeight;
             if (buttonHovered) {
-                NetworkHandler.CHANNEL.sendToServer(new ManualItemTaskPacket());
+                NetworkHandler.CHANNEL.sendToServer(new ManualItemTaskPacket(task.id()));
 
                 if (Minecraft.getInstance().player != null) {
-                    progress.addProgress(GatherItemTask.TYPE, task, Pair.of(ItemStack.EMPTY, Minecraft.getInstance().player.getInventory()));
+                    progress.addProgress(GatherItemTask.TYPE, task, Pair.of(task.id(), Minecraft.getInstance().player.getInventory()));
                 }
                 return true;
             }

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/defaults/GatherItemTask.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/defaults/GatherItemTask.java
@@ -23,17 +23,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 public record GatherItemTask(
-    String id, RegistryValue<Item> item, NbtPredicate nbt, int target, CollectionType collectionType
-) implements PairQuestTask<ItemStack, Container, NumericTag, GatherItemTask> {
+        String id, RegistryValue<Item> item, NbtPredicate nbt, int target, CollectionType collectionType
+) implements PairQuestTask<Object, Container, NumericTag, GatherItemTask> {
 
     public static final QuestTaskType<GatherItemTask> TYPE = new Type();
 
     @Override
-    public NumericTag test(QuestTaskType<?> type, NumericTag progress, ItemStack stack, Container container) {
+    public NumericTag test(QuestTaskType<?> type, NumericTag progress, Object input, Container container) {
         if (this.collectionType == CollectionType.MANUAL) {
-            return manual(progress, container);
-        }
-        if (this.item.is(stack.getItemHolder()) && nbt.matches(stack)) {
+            if (id.equals(input)) {
+                return manual(progress, container);
+            }
+        } else if (input instanceof ItemStack stack && this.item.is(stack.getItemHolder()) && nbt.matches(stack)) {
             return automatic(progress, container);
         }
         return progress;

--- a/common/src/main/java/earth/terrarium/heracles/common/network/packets/tasks/ManualItemTaskPacket.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/network/packets/tasks/ManualItemTaskPacket.java
@@ -10,9 +10,8 @@ import earth.terrarium.heracles.common.handlers.progress.QuestProgressHandler;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.item.ItemStack;
 
-public record ManualItemTaskPacket() implements Packet<ManualItemTaskPacket> {
+public record ManualItemTaskPacket(String task) implements Packet<ManualItemTaskPacket> {
     public static final ResourceLocation ID = new ResourceLocation(Heracles.MOD_ID, "check_item");
     public static final PacketHandler<ManualItemTaskPacket> HANDLER = new Handler();
 
@@ -29,11 +28,13 @@ public record ManualItemTaskPacket() implements Packet<ManualItemTaskPacket> {
     public static class Handler implements PacketHandler<ManualItemTaskPacket> {
 
         @Override
-        public void encode(ManualItemTaskPacket message, FriendlyByteBuf buffer) {}
+        public void encode(ManualItemTaskPacket message, FriendlyByteBuf buffer) {
+            buffer.writeUtf(message.task);
+        }
 
         @Override
         public ManualItemTaskPacket decode(FriendlyByteBuf buffer) {
-            return new ManualItemTaskPacket();
+            return new ManualItemTaskPacket(buffer.readUtf());
         }
 
         @Override
@@ -41,7 +42,7 @@ public record ManualItemTaskPacket() implements Packet<ManualItemTaskPacket> {
             return (player, level) -> {
                 if (player instanceof ServerPlayer serverPlayer) {
                     QuestProgressHandler.getProgress(serverPlayer.getServer(), player.getUUID())
-                        .testAndProgressTaskType(serverPlayer, Pair.of(ItemStack.EMPTY, player.getInventory()), GatherItemTask.TYPE);
+                            .testAndProgressTaskType(serverPlayer, Pair.of(message.task, player.getInventory()), GatherItemTask.TYPE);
                 }
             };
         }


### PR DESCRIPTION
The following have been fixed:
1. Manual tasks are triggered when a player picks up an item
2. Pressing test on a manual task would test all manual tasks.

The following are changed in this PR:
- ManualItemTaskPacket now takes in a string with the id of the task.
- Item task's test function now takes in an object instead of an itemStack, the object could either be a String or an ItemStack. In case of the task being triggered when a player presses the "check task" button it is a string and in case of a player picking up an item, it is an itemStack.
- Now the test function checks if the player picked up an item or pressed the check manually button, in case of the test button being pressed and the task being a manual task it makes sure that the id of the task being checked is equal to itself.

This request is a draft since I am not sure if I was able to properly follow the code styling as well as having the following potential issues:
- Receiving an Object is not ideal, however I can't think of a better solution that does not involve rewriting Minecraft in rust or accepting one more parameter. Theoretically the id check could be done by the progress function.
- I am not sure how many problems tasks with the same id cause, if any at all, right now. With this solution multiple tasks with the id could be triggered with one check button press.

Please comment on every change I should make to this PR.