### PR TITLE
Add quest completion summary

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/CommandRewardWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/CommandRewardWidget.java
@@ -1,6 +1,5 @@
 package earth.terrarium.heracles.api.rewards.client.defaults;
 
-import com.google.common.collect.ImmutableList;
 import com.teamresourceful.resourcefullib.client.scissor.ScissorBoxStack;
 import earth.terrarium.heracles.api.rewards.defaults.CommandReward;
 import net.minecraft.ChatFormatting;

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/BaseQuestScreen.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/BaseQuestScreen.java
@@ -39,7 +39,7 @@ public abstract class BaseQuestScreen extends AbstractQuestScreen<QuestContent> 
     private Button claimRewards;
 
     public BaseQuestScreen(QuestContent content) {
-        super(content, Optionull.mapOrDefault(quest(content), quest -> quest.display().title(), CommonComponents.EMPTY));
+        super(content, Optionull.mapOrDefault(quest(content), quest -> content.progress().isComplete() ? Component.literal("✔ ").append(quest.display().title()).append(Component.literal(" ✔")) : quest.display().title(), CommonComponents.EMPTY));
         ClientQuests.updateProgress(Map.of(content.id(), content.progress()));
     }
 
@@ -69,6 +69,7 @@ public abstract class BaseQuestScreen extends AbstractQuestScreen<QuestContent> 
                 }
             }));
             this.overview.setSelected(true);
+            addRenderableOnly(new QuestProgressWidget(5, this.height - (showRewards ? 60 : 35), buttonWidth, this.quest().tasks().size(), (int) this.quest().tasks().values().stream().filter(t -> this.content.progress().getTask(t).isComplete()).count()));
         }
 
         int buttonY = 45;

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/QuestProgressWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/QuestProgressWidget.java
@@ -1,29 +1,30 @@
-package earth.terrarium.heracles.client.screens.quest.tasks;
+package earth.terrarium.heracles.client.screens.quest;
 
-import com.teamresourceful.resourcefullib.client.scissor.ScissorBoxStack;
-import earth.terrarium.heracles.api.client.DisplayWidget;
-import earth.terrarium.heracles.common.constants.ConstantComponents;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.network.chat.Component;
 
-public record TaskListHeadingWidget(int tasks, int completed) implements DisplayWidget {
+public record QuestProgressWidget(int x, int y, int width, int tasks, int completed) implements Renderable {
 
-    private static final String DESC_SINGULAR = "task.heracles.progress.desc.incomplete.singular";
-    private static final String DESC_PLURAL = "task.heracles.progress.desc.incomplete.plural";
-    private static final String DESC_COMPLETE = "task.heracles.progress.desc.complete";
+    private static final String TITLE_INCOMPLETE =  "gui.heracles.progress.title.incomplete";
+    private static final String TITLE_COMPLETE =  "gui.heracles.progress.title.complete";
+    private static final String DESC_SINGULAR = "gui.heracles.progress.desc.incomplete.singular";
+    private static final String DESC_PLURAL = "gui.heracles.progress.desc.incomplete.plural";
+    private static final String DESC_COMPLETE = "gui.heracles.progress.desc.complete";
 
     @Override
-    public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
         graphics.fill(x, y, x + width, y + 30, 0xD0000000);
         graphics.renderOutline(x, y, width, 30, 0xFFFFFFFF);
 
+        String title = tasks == completed ? TITLE_COMPLETE : TITLE_INCOMPLETE;
         String desc = tasks == completed ? DESC_COMPLETE : (tasks - completed > 1 ? DESC_PLURAL : DESC_SINGULAR);
         String completion = String.format("%.0f%%", this.completed * 100 / (double) tasks);
 
         graphics.drawString(
             Minecraft.getInstance().font,
-            ConstantComponents.Tasks.PROGRESS, x + 5, y + 5, 0xFFFFFFFF,
+            Component.translatable(title), x + 5, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
@@ -36,10 +37,5 @@ public record TaskListHeadingWidget(int tasks, int completed) implements Display
             Component.translatable(desc, tasks - completed), x + 5, y + 25 - Minecraft.getInstance().font.lineHeight, 0xFF696969,
             false
         );
-    }
-
-    @Override
-    public int getHeight(int width) {
-        return 30;
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/tasks/TaskListWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/tasks/TaskListWidget.java
@@ -42,7 +42,7 @@ public class TaskListWidget extends AbstractContainerEventHandler implements Ren
     private final String questId;
     private final ClientQuests.QuestEntry entry;
     private final Map<String, ModUtils.QuestStatus> quests;
-    private final float completion;
+    private final int tasksComplete;
 
     private final int x;
     private final int y;
@@ -63,7 +63,7 @@ public class TaskListWidget extends AbstractContainerEventHandler implements Ren
         Map<String, ModUtils.QuestStatus> quests, BiConsumer<QuestTask<?, ?, ?>, Boolean> onClick, Runnable onCreate
     ) {
         this.progress = progress;
-        this.completion = progress.isComplete() ? 1 : calculationCompletion(entry.value(), progress);
+        this.tasksComplete = (int) entry.value().tasks().values().stream().filter(t -> progress.getTask(t).isComplete()).count();
         this.quests = quests;
         this.questId = questId;
         this.entry = entry;
@@ -99,7 +99,7 @@ public class TaskListWidget extends AbstractContainerEventHandler implements Ren
             }
         }
         this.widgets.clear();
-        this.widgets.add(new MutablePair<>(null, new TaskListHeadingWidget(this.completion, this.quests)));
+        this.widgets.add(new MutablePair<>(null, new TaskListHeadingWidget(this.entry.value().tasks().size(), this.tasksComplete)));
         if (!dependencies.isEmpty()) {
             this.widgets.add(new MutablePair<>(null, DEPENDENCIES));
             this.widgets.addAll(dependencies);
@@ -115,14 +115,6 @@ public class TaskListWidget extends AbstractContainerEventHandler implements Ren
         if (this.onCreate != null) {
             this.widgets.add(new MutablePair<>(null, new AddDisplayWidget(this.onCreate)));
         }
-    }
-
-    private static float calculationCompletion(Quest quest, QuestProgress progress) {
-        float completion = 0;
-        for (var task : quest.tasks().values()) {
-            completion += progress.getTask(task).isComplete() ? 1 : 0;
-        }
-        return completion / quest.tasks().size();
     }
 
     @Override

--- a/common/src/main/resources/assets/heracles/lang/en_us.json
+++ b/common/src/main/resources/assets/heracles/lang/en_us.json
@@ -21,6 +21,11 @@
 
     "gui.heracles.pinned_quests": "Pinned Quests",
     "gui.heracles.pinned_quests.move": "Move Pinned Quests",
+    "gui.heracles.progress.title.incomplete": "Incomplete",
+    "gui.heracles.progress.title.complete": "Complete",
+    "gui.heracles.progress.desc.incomplete.singular": "%s Task Remaining",
+    "gui.heracles.progress.desc.incomplete.plural": "%s Tasks Remaining",
+    "gui.heracles.progress.desc.complete": "All Tasks Completed",
     "gui.heracles.rewards.title": "Rewards",
     "gui.heracles.rewards.create": "Create Reward",
     "gui.heracles.rewards.edit": "Edit Reward",

--- a/common/src/main/resources/assets/heracles_rewards/lang/en_us.json
+++ b/common/src/main/resources/assets/heracles_rewards/lang/en_us.json
@@ -35,7 +35,7 @@
 
     "reward.heracles.command": "/ Command",
     "reward.heracles.command.title.singular": "Execute a Command",
-    "reward.heracles.command.desc.singular": "/%s ...",
-    "reward.heracles.command.tooltip.singular": "Command: /%s",
+    "reward.heracles.command.desc.singular": "%s ...",
+    "reward.heracles.command.tooltip.singular": "Command: %s",
     "setting.heracles.command.command": "Command:"
 }

--- a/common/src/main/resources/assets/heracles_tasks/lang/en_us.json
+++ b/common/src/main/resources/assets/heracles_tasks/lang/en_us.json
@@ -1,6 +1,7 @@
 {
 
-    "task.heracles.progress.desc.incomplete": "%s tasks remaining",
+    "task.heracles.progress.desc.incomplete.singular": "%s task remaining",
+    "task.heracles.progress.desc.incomplete.plural": "%s tasks remaining",
     "task.heracles.progress.desc.complete": "All tasks completed",
 
     "task.heracles.require_quest.title": "Finish Another Quest",


### PR DESCRIPTION
Closes #70

Adds a small summary above the claim rewards button showing quest status, and adds checks to the quest screen title if the quest is complete.

I've used a seperate class to the task list header, but backported the fixes i made while making this one. I'll admit they end up identical beyond the title as a result, but I think it's better off like that - maybe it'll click more how to adjust them after #69 is complete.

![image](https://github.com/terrarium-earth/Heracles/assets/55819817/cbc07394-0323-438a-b25b-031f582bdce3)

![image](https://github.com/terrarium-earth/Heracles/assets/55819817/c35d6f70-6b9d-458f-88ca-4fbdd316514d)

![image](https://github.com/terrarium-earth/Heracles/assets/55819817/d25d43db-f533-4ea1-8dcc-c1af2a319c3a)

Also includes a fix for double slash commands displays.