### PR TITLE
Add reward list header and reward status headers

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/QuestEditScreen.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/QuestEditScreen.java
@@ -97,7 +97,7 @@ public class QuestEditScreen extends BaseQuestScreen {
 
         this.rewardList = new RewardListWidget(
             contentX, contentY, contentWidth, contentHeight, this.entry(),
-            (reward, isRemoving) -> {
+            this.content.progress(), (reward, isRemoving) -> {
                 if (isRemoving) {
                     ClientQuests.updateQuest(this.entry(), quest -> {
                         quest.rewards().remove(reward.id());

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/QuestScreen.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/QuestScreen.java
@@ -41,7 +41,7 @@ public class QuestScreen extends BaseQuestScreen {
         this.taskList = new TaskListWidget(contentX, contentY, contentWidth, contentHeight, this.content.id(), this.entry(), this.content.progress(), this.content.quests(), null, null);
         this.taskList.update(this.quest().tasks().values());
 
-        this.rewardList = new RewardListWidget(contentX, contentY, contentWidth, contentHeight, this.entry(), null, null);
+        this.rewardList = new RewardListWidget(contentX, contentY, contentWidth, contentHeight, this.entry(), this.content.progress(), null, null);
         this.rewardList.update(this.content.fromGroup(), this.content.id(), this.quest());
 
         if (Minecraft.getInstance().player != null && Minecraft.getInstance().player.hasPermissions(2)) {

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/rewards/RewardListHeadingWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/rewards/RewardListHeadingWidget.java
@@ -1,0 +1,45 @@
+package earth.terrarium.heracles.client.screens.quest.rewards;
+
+import com.teamresourceful.resourcefullib.client.scissor.ScissorBoxStack;
+import earth.terrarium.heracles.api.client.DisplayWidget;
+import earth.terrarium.heracles.common.constants.ConstantComponents;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
+
+public record RewardListHeadingWidget(boolean complete, int rewards, int claimed) implements DisplayWidget {
+    private static final String DESC_SINGULAR = "reward.heracles.progress.desc.incomplete.singular";
+    private static final String DESC_PLURAL = "reward.heracles.progress.desc.incomplete.plural";
+    private static final String DESC_COMPLETE = "reward.heracles.progress.desc.complete";
+    private static final String DESC_LOCKED = "reward.heracles.progress.desc.locked";
+
+    @Override
+    public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
+        graphics.fill(x, y, x + width, y + 30, 0xD0000000);
+        graphics.renderOutline(x, y, width, 30, 0xFFFFFFFF);
+
+        String desc = rewards == claimed ? DESC_COMPLETE : (!complete ? DESC_LOCKED : (rewards - claimed > 1 ? DESC_PLURAL : DESC_SINGULAR));
+        String completion = String.format("%.0f%%", this.claimed * 100 / (double) rewards);
+
+        graphics.drawString(
+            Minecraft.getInstance().font,
+            ConstantComponents.Rewards.STATUS, x + 5, y + 5, 0xFFFFFFFF,
+            false
+        );
+        graphics.drawString(
+            Minecraft.getInstance().font,
+            completion, x + width - 5 - Minecraft.getInstance().font.width(completion), y + 5, 0xFFFFFFFF,
+            false
+        );
+        graphics.drawString(
+            Minecraft.getInstance().font,
+            Component.translatable(desc, rewards - claimed), x + 5, y + 25 - Minecraft.getInstance().font.lineHeight, 0xFF696969,
+            false
+        );
+    }
+
+    @Override
+    public int getHeight(int width) {
+        return 30;
+    }
+}

--- a/common/src/main/java/earth/terrarium/heracles/common/constants/ConstantComponents.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/constants/ConstantComponents.java
@@ -110,6 +110,9 @@ public final class ConstantComponents {
         @Translate("Rewards")
         public static final Component TITLE = Component.translatable("gui.heracles.rewards.title");
 
+        @Translate("Reward Status")
+        public static final Component STATUS = Component.translatable("gui.heracles.rewards.status");
+
         @Translate("Create Reward")
         public static final Component CREATE = Component.translatable("gui.heracles.rewards.create");
 

--- a/common/src/main/resources/assets/heracles/lang/en_us.json
+++ b/common/src/main/resources/assets/heracles/lang/en_us.json
@@ -4,6 +4,9 @@
     "quest.heracles.in_progress": "In progress",
     "quest.heracles.completed": "Completed",
     "quest.heracles.dependencies": "Dependencies",
+    "quest.heracles.locked": "Locked",
+    "quest.heracles.available": "Available",
+    "quest.heracles.claimed": "Claimed",
 
     "quest.heracles.toast": "Quest Complete!",
     "quest.heracles.toast.desc": "Press [%s] to open",
@@ -27,6 +30,7 @@
     "gui.heracles.progress.desc.incomplete.plural": "%s Tasks Remaining",
     "gui.heracles.progress.desc.complete": "All Tasks Completed",
     "gui.heracles.rewards.title": "Rewards",
+    "gui.heracles.rewards.status": "Reward Status",
     "gui.heracles.rewards.create": "Create Reward",
     "gui.heracles.rewards.edit": "Edit Reward",
     "gui.heracles.rewards.select_claim": "Claim this Reward",

--- a/common/src/main/resources/assets/heracles_rewards/lang/en_us.json
+++ b/common/src/main/resources/assets/heracles_rewards/lang/en_us.json
@@ -1,4 +1,9 @@
 {
+    "reward.heracles.progress.desc.incomplete.singular": "%s reward available",
+    "reward.heracles.progress.desc.incomplete.plural": "%s rewards available",
+    "reward.heracles.progress.desc.locked": "No rewards available",
+    "reward.heracles.progress.desc.complete": "All rewards claimed",
+
     "gui.heracles.rewards.unlocks_quest.title": "Unlocks %s",
     "gui.heracles.rewards.unlocks_quest.desc": "Grants you access to a new quest.",
 


### PR DESCRIPTION
Closes #69

Brings the rewards screen in-grade with the tasks screen by showing reward status per-reward, and having an overall progress header that serves as a title for the screen. 

![javaw_bnNME6evTi](https://github.com/terrarium-earth/Heracles/assets/55819817/13a0f24a-15d4-4214-bf2e-5d5537947b63)

![javaw_tT6yXTyzhm](https://github.com/terrarium-earth/Heracles/assets/55819817/f02be1fe-b8af-4525-82eb-60025da80173)

![javaw_FkkC8Oxys5](https://github.com/terrarium-earth/Heracles/assets/55819817/c4628d45-5443-4791-9648-be07e50f3253)

Old screen for comparison:

![image](https://github.com/terrarium-earth/Heracles/assets/55819817/d877c816-a2b7-4029-a2ba-433e20739748)

Feel free to tweak header colours before merging if desired.