### PR TITLE
Change scaling for task and reward widgets.

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/api/client/WidgetUtils.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/client/WidgetUtils.java
@@ -42,7 +42,7 @@ public final class WidgetUtils {
         String text = QuestTaskDisplayFormatter.create(task, progress);
         graphics.drawString(
             font,
-            text, x + width - 5 - font.width(text), y + 5, 0xFFFFFFFF,
+            text, x + width - 5 - font.width(text), y + 6, 0xFFFFFFFF,
             false
         );
     }

--- a/common/src/main/java/earth/terrarium/heracles/api/client/WidgetUtils.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/client/WidgetUtils.java
@@ -86,13 +86,11 @@ public final class WidgetUtils {
 
     public static void drawItemIcon(GuiGraphics graphics, ItemStack icon, int x, int y, int iconSize) {
         int scale = iconSize / 16;
-        graphics.pose().pushPose();
-        graphics.pose().translate(1, 1, 0);
-        graphics.pose().pushPose();
-        graphics.pose().scale(scale, scale, 1);
-        graphics.renderFakeItem(icon, (x + 5 + (int) ((iconSize / scale) / 2f) - 8) / scale, (y + 5 + (int) ((iconSize / scale) / 2f) - 8) / scale);
-        graphics.pose().popPose();
-        graphics.pose().popPose();
+        try (var pose = new CloseablePoseStack(graphics)) {
+            pose.translate(1, 1, 0);
+            pose.scale(scale, scale, 1);
+            graphics.renderFakeItem(icon, (x + 5 + (int) ((iconSize / scale) / 2f) - 8) / scale, (y + 5 + (int) ((iconSize / scale) / 2f) - 8) / scale);
+        }
     }
 
     public static void drawItemIconWithTooltip(GuiGraphics graphics, ItemStack icon, int x, int y, int iconSize, Supplier<List<Component>> tooltipCallback, int mouseX, int mouseY) {

--- a/common/src/main/java/earth/terrarium/heracles/api/client/WidgetUtils.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/client/WidgetUtils.java
@@ -24,9 +24,9 @@ import java.util.function.Supplier;
 
 public final class WidgetUtils {
 
-    public static void drawBackground(GuiGraphics graphics, int x, int y, int width) {
-        graphics.fill(x, y, x + width, y + (int) (width * 0.1f) + 10, 0x80808080);
-        graphics.renderOutline(x, y, width, (int) (width * 0.1f) + 10, 0xFF909090);
+    public static void drawBackground(GuiGraphics graphics, int x, int y, int width, int height) {
+        graphics.fill(x, y, x + width, y + height, 0x80808080);
+        graphics.renderOutline(x, y, width, height, 0xFF909090);
     }
 
     public static <T extends Tag> void drawProgressBar(GuiGraphics graphics, int minX, int minY, int maxX, int maxY, QuestTask<?, T, ?> task, TaskProgress<T> progress) {
@@ -85,14 +85,21 @@ public final class WidgetUtils {
     }
 
     public static void drawItemIcon(GuiGraphics graphics, ItemStack icon, int x, int y, int iconSize) {
-        graphics.renderFakeItem(icon, x + 5 + (int) (iconSize / 2f) - 8, y + 5 + (int) (iconSize / 2f) - 8);
+        int scale = iconSize / 16;
+        graphics.pose().pushPose();
+        graphics.pose().translate(1, 1, 0);
+        graphics.pose().pushPose();
+        graphics.pose().scale(scale, scale, 1);
+        graphics.renderFakeItem(icon, (x + 5 + (int) ((iconSize / scale) / 2f) - 8) / scale, (y + 5 + (int) ((iconSize / scale) / 2f) - 8) / scale);
+        graphics.pose().popPose();
+        graphics.pose().popPose();
     }
 
     public static void drawItemIconWithTooltip(GuiGraphics graphics, ItemStack icon, int x, int y, int iconSize, Supplier<List<Component>> tooltipCallback, int mouseX, int mouseY) {
         WidgetUtils.drawItemIcon(graphics, icon, x, y, iconSize);
-        int xMin = x + 5 + (int) (iconSize / 2f) - 8 - 2;
-        int yMin = y + 5 + (int) (iconSize / 2f) - 8 - 2;
-        boolean inBounds = (mouseX >= xMin && mouseX < xMin + 20) && (mouseY >= yMin && mouseY < yMin + 20);
+        int xMin = x + 5;
+        int yMin = y + 5;
+        boolean inBounds = (mouseX >= xMin && mouseX < xMin + iconSize) && (mouseY >= yMin && mouseY < yMin + iconSize);
         if (inBounds) {
             List<Component> tooltipLines = tooltipCallback.get();
             if (tooltipLines != null) {

--- a/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/BaseItemRewardWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/BaseItemRewardWidget.java
@@ -4,7 +4,6 @@ import com.teamresourceful.resourcefullib.client.scissor.ScissorBoxStack;
 import earth.terrarium.heracles.api.client.DisplayWidget;
 import earth.terrarium.heracles.api.client.WidgetUtils;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
@@ -18,16 +17,16 @@ public interface BaseItemRewardWidget extends DisplayWidget {
 
     @Override
     default void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
-        Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         ItemStack icon = getIcon();
         WidgetUtils.drawItemIconWithTooltip(graphics, icon, x, y, iconSize, this::getTooltip, mouseX, mouseY);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
     }
 
     @Override
     default int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 
     default List<Component> getTooltip() {

--- a/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/CommandRewardWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/CommandRewardWidget.java
@@ -31,12 +31,12 @@ public record CommandRewardWidget(CommandReward reward) implements BaseItemRewar
         String desc = firstSpace > 0 ? reward.command().substring(0, reward.command().indexOf(" ")) : reward.command();
         graphics.drawString(
             font,
-            Component.translatable(TITLE_SINGULAR), x + (int) (width * 0.1f) + 10, y + 5, 0xFFFFFFFF,
+            Component.translatable(TITLE_SINGULAR), x + 48, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(DESC_SINGULAR, desc), x + (int) (width * 0.1f) + 10, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(DESC_SINGULAR, desc), x + 48, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
     }

--- a/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/CommandRewardWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/CommandRewardWidget.java
@@ -31,12 +31,12 @@ public record CommandRewardWidget(CommandReward reward) implements BaseItemRewar
         String desc = firstSpace > 0 ? reward.command().substring(0, reward.command().indexOf(" ")) : reward.command();
         graphics.drawString(
             font,
-            Component.translatable(TITLE_SINGULAR), x + 48, y + 5, 0xFFFFFFFF,
+            Component.translatable(TITLE_SINGULAR), x + 48, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(DESC_SINGULAR, desc), x + 48, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(DESC_SINGULAR, desc), x + 48, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
     }

--- a/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/ItemRewardWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/ItemRewardWidget.java
@@ -28,12 +28,12 @@ public record ItemRewardWidget(ItemReward reward) implements BaseItemRewardWidge
         String desc = getIcon().getCount() == 1 ? DESC_SINGULAR : DESC_PLURAL;
         graphics.drawString(
             font,
-            Component.translatable(title, getIcon().getHoverName()), x + 48, y + 5, 0xFFFFFFFF,
+            Component.translatable(title, getIcon().getHoverName()), x + 48, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(desc, getIcon().getCount(), getIcon().getHoverName()), x + 48, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(desc, getIcon().getCount(), getIcon().getHoverName()), x + 48, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
     }

--- a/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/ItemRewardWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/ItemRewardWidget.java
@@ -28,12 +28,12 @@ public record ItemRewardWidget(ItemReward reward) implements BaseItemRewardWidge
         String desc = getIcon().getCount() == 1 ? DESC_SINGULAR : DESC_PLURAL;
         graphics.drawString(
             font,
-            Component.translatable(title, getIcon().getHoverName()), x + (int) (width * 0.1f) + 10, y + 5, 0xFFFFFFFF,
+            Component.translatable(title, getIcon().getHoverName()), x + 48, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(desc, getIcon().getCount(), getIcon().getHoverName()), x + (int) (width * 0.1f) + 10, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(desc, getIcon().getCount(), getIcon().getHoverName()), x + 48, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
     }

--- a/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/LootTableRewardWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/LootTableRewardWidget.java
@@ -29,12 +29,12 @@ public record LootTableRewardWidget(LootTableReward reward) implements BaseItemR
         BaseItemRewardWidget.super.render(graphics, scissor, x, y, width, mouseX, mouseY, hovered, partialTicks);
         graphics.drawString(
             font,
-            TITLE_SINGULAR, x + 48, y + 5, 0xFFFFFFFF,
+            TITLE_SINGULAR, x + 48, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(DESC_SINGULAR, this.reward.lootTable()), x + 48, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(DESC_SINGULAR, this.reward.lootTable()), x + 48, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
     }

--- a/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/LootTableRewardWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/LootTableRewardWidget.java
@@ -1,6 +1,5 @@
 package earth.terrarium.heracles.api.rewards.client.defaults;
 
-import com.google.common.collect.ImmutableList;
 import com.teamresourceful.resourcefullib.client.scissor.ScissorBoxStack;
 import earth.terrarium.heracles.api.rewards.defaults.LootTableReward;
 import net.minecraft.ChatFormatting;
@@ -30,12 +29,12 @@ public record LootTableRewardWidget(LootTableReward reward) implements BaseItemR
         BaseItemRewardWidget.super.render(graphics, scissor, x, y, width, mouseX, mouseY, hovered, partialTicks);
         graphics.drawString(
             font,
-            TITLE_SINGULAR, x + (int) (width * 0.1f) + 10, y + 5, 0xFFFFFFFF,
+            TITLE_SINGULAR, x + 48, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(DESC_SINGULAR, this.reward.lootTable()), x + (int) (width * 0.1f) + 10, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(DESC_SINGULAR, this.reward.lootTable()), x + 48, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
     }

--- a/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/SelectableRewardWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/SelectableRewardWidget.java
@@ -51,12 +51,12 @@ public record SelectableRewardWidget(SelectableReward reward, String quest,
         String desc = this.reward.amount() == 1 ? DESC_SINGULAR : DESC_PLURAL;
         graphics.drawString(
             font,
-            Component.translatable(title), x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            Component.translatable(title), x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(desc, this.reward.amount()), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(desc, this.reward.amount()), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
 

--- a/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/SelectableRewardWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/SelectableRewardWidget.java
@@ -44,19 +44,19 @@ public record SelectableRewardWidget(SelectableReward reward, String quest,
     @Override
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         WidgetUtils.drawItemIcon(graphics, Items.CHEST.getDefaultInstance(), x, y, iconSize);
         String title = this.reward.amount() == 1 ? TITLE_SINGULAR : TITLE_PLURAL;
         String desc = this.reward.amount() == 1 ? DESC_SINGULAR : DESC_PLURAL;
         graphics.drawString(
             font,
-            Component.translatable(title), x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            Component.translatable(title), x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(desc, this.reward.amount()), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(desc, this.reward.amount()), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
 
@@ -104,6 +104,6 @@ public record SelectableRewardWidget(SelectableReward reward, String quest,
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/XpRewardWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/XpRewardWidget.java
@@ -28,12 +28,12 @@ public record XpRewardWidget(XpQuestReward reward) implements DisplayWidget {
         String desc = this.reward.amount() == 1 ? DESC_SINGULAR : DESC_PLURAL;
         graphics.drawString(
             font,
-            Component.translatable(title, this.reward.amount()), x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            Component.translatable(title, this.reward.amount()), x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(desc, this.reward.amount(), this.reward.xpType().text()), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(desc, this.reward.amount(), this.reward.xpType().text()), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
     }

--- a/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/XpRewardWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/rewards/client/defaults/XpRewardWidget.java
@@ -20,25 +20,26 @@ public record XpRewardWidget(XpQuestReward reward) implements DisplayWidget {
     @Override
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         WidgetUtils.drawItemIcon(graphics, Items.EXPERIENCE_BOTTLE.getDefaultInstance(), x, y, iconSize);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         String title = this.reward.amount() == 1 ? TITLE_SINGULAR : TITLE_PLURAL;
         String desc = this.reward.amount() == 1 ? DESC_SINGULAR : DESC_PLURAL;
         graphics.drawString(
             font,
-            Component.translatable(title, this.reward.amount()), x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            Component.translatable(title, this.reward.amount()), x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(desc, this.reward.amount(), this.reward.xpType().text()), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(desc, this.reward.amount(), this.reward.xpType().text()), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
     }
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/AdvancementTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/AdvancementTaskWidget.java
@@ -72,18 +72,18 @@ public final class AdvancementTaskWidget implements DisplayWidget {
         Object text = this.task.advancements().size() == 1 ? this.titles.isEmpty() ? "" : this.titles.get(0) : isOpened ? "▼" : "▶";
         graphics.drawString(
             font,
-            this.title, x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            this.title, x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(desc, text), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(desc, text), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
         graphics.drawString(
             font,
-            progress, x + width - 5 - font.width(progress), y + 5, 0xFFFFFFFF,
+            progress, x + width - 5 - font.width(progress), y + 6, 0xFFFFFFFF,
             false
         );
 
@@ -104,7 +104,7 @@ public final class AdvancementTaskWidget implements DisplayWidget {
             }
         }
 
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, actualY + height - font.lineHeight - 6, x + width - 5, actualY + height - 5, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, actualY + height - font.lineHeight - 5, x + width - 5, actualY + height - 6, this.task, this.progress);
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/AdvancementTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/AdvancementTaskWidget.java
@@ -65,18 +65,19 @@ public final class AdvancementTaskWidget implements DisplayWidget {
         graphics.fill(x, y, x + width, y + height, 0x80808080);
         graphics.renderOutline(x, y, width, height, 0xFF909090);
 
-        int iconSize = (int) (width * 0.1f);
+        int iconSize = 32;
         WidgetUtils.drawItemIcon(graphics, getCurrentItem(), x, y, iconSize);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         String desc = this.task.advancements().size() == 1 ? DESC_SINGULAR : DESC_PLURAL;
         Object text = this.task.advancements().size() == 1 ? this.titles.isEmpty() ? "" : this.titles.get(0) : isOpened ? "▼" : "▶";
         graphics.drawString(
             font,
-            this.title, x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            this.title, x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(desc, text), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(desc, text), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
@@ -103,7 +104,7 @@ public final class AdvancementTaskWidget implements DisplayWidget {
             }
         }
 
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 10, actualY + height - font.lineHeight + 2, x + width - 5, actualY + height - 2, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, actualY + height - font.lineHeight - 6, x + width - 5, actualY + height - 5, this.task, this.progress);
     }
 
     @Override
@@ -123,9 +124,9 @@ public final class AdvancementTaskWidget implements DisplayWidget {
     @Override
     public int getHeight(int width) {
         if (isOpened) {
-            return (int) (width * 0.1f) + 10 + (Minecraft.getInstance().font.lineHeight + 2) * (this.titles.size());
+            return 42 + (Minecraft.getInstance().font.lineHeight + 2) * (this.titles.size());
         }
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 
     private ItemStack getCurrentItem() {

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/BiomeTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/BiomeTaskWidget.java
@@ -37,23 +37,23 @@ public final class BiomeTaskWidget implements DisplayWidget {
         graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            DESCRIPTION, x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            DESCRIPTION, x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
         graphics.drawString(
             font,
-            progress, x + width - 5 - font.width(progress), y + 5, 0xFFFFFFFF,
+            progress, x + width - 5 - font.width(progress), y + 6, 0xFFFFFFFF,
             false
         );
 
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 5, x + width - 5, y + height - 6, this.task, this.progress);
     }
 
     private static final Item[] ICONS = {

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/BiomeTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/BiomeTaskWidget.java
@@ -31,17 +31,18 @@ public final class BiomeTaskWidget implements DisplayWidget {
     @Override
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         WidgetUtils.drawItemIcon(graphics, getIcon(), x, y, iconSize);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            DESCRIPTION, x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            DESCRIPTION, x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
@@ -52,7 +53,7 @@ public final class BiomeTaskWidget implements DisplayWidget {
         );
 
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 10, y + height - font.lineHeight + 2, x + width - 5, y + height - 2, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
     }
 
     private static final Item[] ICONS = {
@@ -67,7 +68,7 @@ public final class BiomeTaskWidget implements DisplayWidget {
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/BlockInteractTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/BlockInteractTaskWidget.java
@@ -40,23 +40,23 @@ public record BlockInteractTaskWidget(
         graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(DESC, Component.keybind("key.use")), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(DESC, Component.keybind("key.use")), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
         graphics.drawString(
             font,
-            progress, x + width - 5 - font.width(progress), y + 5, 0xFFFFFFFF,
+            progress, x + width - 5 - font.width(progress), y + 6, 0xFFFFFFFF,
             false
         );
 
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 5, x + width - 5, y + height - 6, this.task, this.progress);
     }
 
     private ItemStack getCurrentItem() {

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/BlockInteractTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/BlockInteractTaskWidget.java
@@ -34,17 +34,18 @@ public record BlockInteractTaskWidget(
     @Override
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         WidgetUtils.drawItemIconWithTooltip(graphics, getCurrentItem(), x, y, iconSize, mouseX, mouseY);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(DESC, Component.keybind("key.use")), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(DESC, Component.keybind("key.use")), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
@@ -55,7 +56,7 @@ public record BlockInteractTaskWidget(
         );
 
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 10, y + height - font.lineHeight + 2, x + width - 5, y + height - 2, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
     }
 
     private ItemStack getCurrentItem() {
@@ -68,7 +69,7 @@ public record BlockInteractTaskWidget(
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/CheckTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/CheckTaskWidget.java
@@ -32,17 +32,18 @@ public record CheckTaskWidget(
     @Override
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
-        graphics.blit(CHECK_TEXTURE, x + 5 + (int) (iconSize / 2f) - 8, y + 5 + (int) (iconSize / 2f) - 8, 0, 0, 16, 16, 16, 16);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
+        graphics.blit(CHECK_TEXTURE, x + 5, y + 5, 0, 0, 32, 32, 32, 32);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(task), x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(DESC_SINGULAR), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(DESC_SINGULAR), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
 
@@ -73,6 +74,6 @@ public record CheckTaskWidget(
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/CheckTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/CheckTaskWidget.java
@@ -38,12 +38,12 @@ public record CheckTaskWidget(
         graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(task), x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(DESC_SINGULAR), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(DESC_SINGULAR), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
 

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/CompositeTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/CompositeTaskWidget.java
@@ -60,7 +60,7 @@ public final class CompositeTaskWidget implements DisplayWidget {
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
         graphics.drawString(
             font,
-            progress, x + width - 5 - font.width(progress), y + 5, 0xFFFFFFFF,
+            progress, x + width - 5 - font.width(progress), y + 6, 0xFFFFFFFF,
             false
         );
 

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/CompositeTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/CompositeTaskWidget.java
@@ -49,7 +49,7 @@ public final class CompositeTaskWidget implements DisplayWidget {
         Font font = Minecraft.getInstance().font;
         int start = graphics.drawString(
             font,
-            isOpened ? "▼" : "▶", x + (int) (width * 0.1f) + 10, y + 5, 0xFFFFFFFF,
+            isOpened ? "▼" : "▶", x + 48, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/DimensionTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/DimensionTaskWidget.java
@@ -34,17 +34,18 @@ public final class DimensionTaskWidget implements DisplayWidget {
     @Override
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         WidgetUtils.drawItemIcon(graphics, getIcon(), x, y, iconSize);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            getDescription(), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            getDescription(), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
@@ -55,7 +56,7 @@ public final class DimensionTaskWidget implements DisplayWidget {
         );
 
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 10, y + height - font.lineHeight + 2, x + width - 5, y + height - 2, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
     }
 
     private Component getDescription() {
@@ -82,7 +83,7 @@ public final class DimensionTaskWidget implements DisplayWidget {
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/DimensionTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/DimensionTaskWidget.java
@@ -40,23 +40,23 @@ public final class DimensionTaskWidget implements DisplayWidget {
         graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            getDescription(), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            getDescription(), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
         graphics.drawString(
             font,
-            progress, x + width - 5 - font.width(progress), y + 5, 0xFFFFFFFF,
+            progress, x + width - 5 - font.width(progress), y + 6, 0xFFFFFFFF,
             false
         );
 
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 5, x + width - 5, y + height - 6, this.task, this.progress);
     }
 
     private Component getDescription() {

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/DummyTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/DummyTaskWidget.java
@@ -25,17 +25,17 @@ public record DummyTaskWidget(
         graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            this.task.description() == null ? CommonComponents.EMPTY : this.task.description(), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            this.task.description() == null ? CommonComponents.EMPTY : this.task.description(), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
         WidgetUtils.drawProgressText(graphics, x, y, width, this.task, this.progress);
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 5, x + width - 5, y + height - 6, this.task, this.progress);
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/DummyTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/DummyTaskWidget.java
@@ -19,26 +19,27 @@ public record DummyTaskWidget(
     @Override
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         WidgetUtils.drawItemIcon(graphics, task.icon().getDefaultInstance(), x, y, iconSize);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            this.task.description() == null ? CommonComponents.EMPTY : this.task.description(), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            this.task.description() == null ? CommonComponents.EMPTY : this.task.description(), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
         WidgetUtils.drawProgressText(graphics, x, y, width, this.task, this.progress);
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 10, y + height - font.lineHeight + 2, x + width - 5, y + height - 2, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
     }
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/EntityInteractTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/EntityInteractTaskWidget.java
@@ -40,8 +40,8 @@ public record EntityInteractTaskWidget(
     @Override
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         EntityType<?> type = getType();
         if (type != null) {
             Entity entity = factory.apply(type);
@@ -49,14 +49,15 @@ public record EntityInteractTaskWidget(
                 WidgetUtils.drawEntity(graphics, x + 5, y + 5, iconSize, entity);
             }
         }
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(DESC, Component.keybind("key.use")), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(DESC, Component.keybind("key.use")), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
@@ -67,12 +68,12 @@ public record EntityInteractTaskWidget(
         );
 
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 10, y + height - font.lineHeight + 2, x + width - 5, y + height - 2, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
     }
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 
     private EntityType<?> getType() {

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/EntityInteractTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/EntityInteractTaskWidget.java
@@ -52,23 +52,23 @@ public record EntityInteractTaskWidget(
         graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(DESC, Component.keybind("key.use")), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(DESC, Component.keybind("key.use")), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
         graphics.drawString(
             font,
-            progress, x + width - 5 - font.width(progress), y + 5, 0xFFFFFFFF,
+            progress, x + width - 5 - font.width(progress), y + 6, 0xFFFFFFFF,
             false
         );
 
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 5, x + width - 5, y + height - 6, this.task, this.progress);
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/ItemInteractTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/ItemInteractTaskWidget.java
@@ -37,23 +37,24 @@ public record ItemInteractTaskWidget(
     @Override
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         ItemStack item = this.getCurrentItem();
         WidgetUtils.drawItemIconWithTooltip(graphics, item, x, y, iconSize, mouseX, mouseY);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(DESC, Component.keybind("key.use")), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(DESC, Component.keybind("key.use")), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
         WidgetUtils.drawProgressText(graphics, x, y, width, this.task, this.progress);
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 10, y + height - font.lineHeight + 2, x + width - 5, y + height - 2, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
     }
 
     private ItemStack getCurrentItem() {
@@ -66,6 +67,6 @@ public record ItemInteractTaskWidget(
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/ItemInteractTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/ItemInteractTaskWidget.java
@@ -44,17 +44,17 @@ public record ItemInteractTaskWidget(
         graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(DESC, Component.keybind("key.use")), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(DESC, Component.keybind("key.use")), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
         WidgetUtils.drawProgressText(graphics, x, y, width, this.task, this.progress);
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 5, x + width - 5, y + height - 6, this.task, this.progress);
     }
 
     private ItemStack getCurrentItem() {

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/ItemTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/ItemTaskWidget.java
@@ -57,33 +57,33 @@ public final class ItemTaskWidget implements DisplayWidget {
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Minecraft minecraft = Minecraft.getInstance();
         Font font = minecraft.font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         ItemStack item = this.getCurrentItem();
         WidgetUtils.drawItemIconWithTooltip(graphics, item, x, y, iconSize, mouseX, mouseY);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         String title = chooseGatherKey(task, TITLE_ITEM, TITLE_TAG, TITLE_SUBMIT_ITEM, TITLE_SUBMIT_TAG);
         String desc = chooseGatherKey(task, DESC_ITEM, DESC_TAG, DESC_SUBMIT_ITEM, DESC_SUBMIT_TAG);
         graphics.drawString(
             font,
-            Component.translatable(title, task.item().getDisplayName(Item::getDescription)), x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            Component.translatable(title, task.item().getDisplayName(Item::getDescription)), x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(desc, this.task.target(), task.item().getDisplayName(Item::getDescription)), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(desc, this.task.target(), task.item().getDisplayName(Item::getDescription)), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
         WidgetUtils.drawProgressText(graphics, x, y, width, this.task, this.progress);
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 10, y + height - font.lineHeight + 2, x + width - 5, y + height - 2, this.task, this.progress);
-
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
         if (task.collectionType() == CollectionType.MANUAL) {
-            int buttonY = y + height - font.lineHeight - 10;
+            int buttonY = y + height - font.lineHeight - 17;
             int buttonWidth = font.width(ConstantComponents.Tasks.SUBMIT);
-            boolean buttonHovered = mouseX > x + width - 2 - buttonWidth && mouseX < x + width - 2 && mouseY > buttonY && mouseY < buttonY + font.lineHeight;
+            boolean buttonHovered = mouseX > x + width - 5 - buttonWidth && mouseX < x + width - 5 && mouseY > buttonY && mouseY < buttonY + font.lineHeight;
 
             Component text = buttonHovered ? ConstantComponents.Tasks.SUBMIT.copy().withStyle(ChatFormatting.UNDERLINE) : ConstantComponents.Tasks.SUBMIT;
-            graphics.drawString(font, text, x + width - 2 - buttonWidth, buttonY, progress.isComplete() ? 0xFF707070 : 0xFFD0D0D0, false);
+            graphics.drawString(font, text, x + width - 5 - buttonWidth, buttonY, progress.isComplete() ? 0xFF707070 : 0xFFD0D0D0, false);
             CursorUtils.setCursor(buttonHovered, progress.isComplete() ? CursorScreen.Cursor.DISABLED : CursorScreen.Cursor.POINTER);
             if (buttonHovered) {
                 ScreenUtils.setTooltip(Component.translatable("task.heracles.item.submit.button.tooltip", this.task.target()));
@@ -112,8 +112,9 @@ public final class ItemTaskWidget implements DisplayWidget {
     public boolean mouseClicked(double mouseX, double mouseY, int mouseButton, int width) {
         if (task.collectionType() == CollectionType.MANUAL && !progress.isComplete()) {
             Font font = Minecraft.getInstance().font;
-            int buttonY = getHeight(width) - 19;
-            boolean buttonHovered = mouseX > width - 2 - font.width(ConstantComponents.Tasks.SUBMIT) && mouseX < width - 2 && mouseY > buttonY && mouseY < buttonY + font.lineHeight;
+            int buttonY = getHeight(width) - font.lineHeight - 17;
+            int buttonWidth = font.width(ConstantComponents.Tasks.SUBMIT);
+            boolean buttonHovered = mouseX > width - 5 - buttonWidth && mouseX < width - 5 && mouseY > buttonY && mouseY < buttonY + font.lineHeight;
             if (buttonHovered) {
                 NetworkHandler.CHANNEL.sendToServer(new ManualItemTaskPacket(this.quest, this.task.id()));
 
@@ -136,6 +137,6 @@ public final class ItemTaskWidget implements DisplayWidget {
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/ItemTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/ItemTaskWidget.java
@@ -66,19 +66,19 @@ public final class ItemTaskWidget implements DisplayWidget {
         String desc = chooseGatherKey(task, DESC_ITEM, DESC_TAG, DESC_SUBMIT_ITEM, DESC_SUBMIT_TAG);
         graphics.drawString(
             font,
-            Component.translatable(title, task.item().getDisplayName(Item::getDescription)), x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            Component.translatable(title, task.item().getDisplayName(Item::getDescription)), x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(desc, this.task.target(), task.item().getDisplayName(Item::getDescription)), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(desc, this.task.target(), task.item().getDisplayName(Item::getDescription)), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
         WidgetUtils.drawProgressText(graphics, x, y, width, this.task, this.progress);
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 5, x + width - 5, y + height - 6, this.task, this.progress);
         if (task.collectionType() == CollectionType.MANUAL) {
-            int buttonY = y + height - font.lineHeight - 17;
+            int buttonY = y + height - font.lineHeight - 16;
             int buttonWidth = font.width(ConstantComponents.Tasks.SUBMIT);
             boolean buttonHovered = mouseX > x + width - 5 - buttonWidth && mouseX < x + width - 5 && mouseY > buttonY && mouseY < buttonY + font.lineHeight;
 
@@ -112,7 +112,7 @@ public final class ItemTaskWidget implements DisplayWidget {
     public boolean mouseClicked(double mouseX, double mouseY, int mouseButton, int width) {
         if (task.collectionType() == CollectionType.MANUAL && !progress.isComplete()) {
             Font font = Minecraft.getInstance().font;
-            int buttonY = getHeight(width) - font.lineHeight - 17;
+            int buttonY = getHeight(width) - font.lineHeight - 16;
             int buttonWidth = font.width(ConstantComponents.Tasks.SUBMIT);
             boolean buttonHovered = mouseX > width - 5 - buttonWidth && mouseX < width - 5 && mouseY > buttonY && mouseY < buttonY + font.lineHeight;
             if (buttonHovered) {

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/KillEntityTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/KillEntityTaskWidget.java
@@ -47,23 +47,23 @@ public record KillEntityTaskWidget(KillEntityQuestTask task, TaskProgress<Numeri
         Component entityName = this.task.entity().entityType().getDescription();
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(desc, this.task.target(), entityName), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(desc, this.task.target(), entityName), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
         graphics.drawString(
             font,
-            progress, x + width - 5 - font.width(progress), y + 5, 0xFFFFFFFF,
+            progress, x + width - 5 - font.width(progress), y + 6, 0xFFFFFFFF,
             false
         );
 
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 5, x + width - 5, y + height - 6, this.task, this.progress);
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/KillEntityTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/KillEntityTaskWidget.java
@@ -36,22 +36,23 @@ public record KillEntityTaskWidget(KillEntityQuestTask task, TaskProgress<Numeri
     @Override
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         Entity entity = factory.apply(this.task.entity().entityType());
         try (var ignored = RenderUtils.createScissorBoxStack(scissor, Minecraft.getInstance(), graphics.pose(), x + 5, y + 5, iconSize, iconSize)) {
             WidgetUtils.drawEntity(graphics, x + 5, y + 5, iconSize, entity);
         }
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         String desc = this.task.target() == 1 ? DESC_SINGULAR : DESC_PLURAL;
         Component entityName = this.task.entity().entityType().getDescription();
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(desc, this.task.target(), entityName), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(desc, this.task.target(), entityName), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
@@ -62,11 +63,11 @@ public record KillEntityTaskWidget(KillEntityQuestTask task, TaskProgress<Numeri
         );
 
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 10, y + height - font.lineHeight + 2, x + width - 5, y + height - 2, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
     }
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/LocationTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/LocationTaskWidget.java
@@ -21,11 +21,11 @@ public record LocationTaskWidget(
         int iconSize = 32;
         WidgetUtils.drawItemIcon(graphics, this.task.icon().getDefaultInstance(), x, y, iconSize);
         graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
-        graphics.drawString(font, this.task.title(), x + iconSize + 16, y + 5, 0xFFFFFFFF, false);
-        graphics.drawString(font, this.task.desc(), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080, false);
+        graphics.drawString(font, this.task.title(), x + iconSize + 16, y + 6, 0xFFFFFFFF, false);
+        graphics.drawString(font, this.task.desc(), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080, false);
         WidgetUtils.drawProgressText(graphics, x, y, width, this.task, this.progress);
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 5, x + width - 5, y + height - 6, this.task, this.progress);
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/LocationTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/LocationTaskWidget.java
@@ -17,19 +17,20 @@ public record LocationTaskWidget(
     @Override
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         WidgetUtils.drawItemIcon(graphics, this.task.icon().getDefaultInstance(), x, y, iconSize);
-        graphics.drawString(font, this.task.title(), x + iconSize + 10, y + 5, 0xFFFFFFFF, false);
-        graphics.drawString(font, this.task.desc(), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080, false);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
+        graphics.drawString(font, this.task.title(), x + iconSize + 16, y + 5, 0xFFFFFFFF, false);
+        graphics.drawString(font, this.task.desc(), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080, false);
         WidgetUtils.drawProgressText(graphics, x, y, width, this.task, this.progress);
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 10, y + height - font.lineHeight + 2, x + width - 5, y + height - 2, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
     }
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/RecipeTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/RecipeTaskWidget.java
@@ -64,18 +64,19 @@ public final class RecipeTaskWidget implements DisplayWidget {
         graphics.fill(x, y, x + width, y + height, 0x80808080);
         graphics.renderOutline(x, y, width, height, 0xFF909090);
 
-        int iconSize = (int) (width * 0.1f);
+        int iconSize = 32;
         WidgetUtils.drawItemIcon(graphics, getCurrentItem(), x, y, iconSize);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         String desc = this.task.recipes().size() == 1 ? DESC_SINGULAR : DESC_PLURAL;
         Object text = this.task.recipes().size() == 1 ? this.titles.isEmpty() ? "" : this.titles.get(0) : isOpened ? "▼" : "▶";
         graphics.drawString(
             font,
-            this.title, x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            this.title, x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(desc, text), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(desc, text), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
@@ -102,13 +103,13 @@ public final class RecipeTaskWidget implements DisplayWidget {
             }
         }
 
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 10, actualY + height - font.lineHeight + 2, x + width - 5, actualY + height - 2, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, actualY + height - font.lineHeight - 6, x + width - 5, actualY + height - 5, this.task, this.progress);
     }
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int mouseButton, int width) {
         if (mouseY < 0 || mouseY > getHeight(width)) return false;
-        if (mouseX < (int) (width * 0.1f) || mouseX > width) return false;
+        if (mouseX < 32 || mouseX > width) return false;
         if (mouseButton != 0) return false;
         if (this.titles.size() <= 1) return false;
         Font font = Minecraft.getInstance().font;
@@ -122,9 +123,9 @@ public final class RecipeTaskWidget implements DisplayWidget {
     @Override
     public int getHeight(int width) {
         if (isOpened) {
-            return (int) (width * 0.1f) + 10 + (Minecraft.getInstance().font.lineHeight + 2) * (this.titles.size());
+            return 42 + (Minecraft.getInstance().font.lineHeight + 2) * (this.titles.size());
         }
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 
     private ItemStack getCurrentItem() {

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/RecipeTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/RecipeTaskWidget.java
@@ -71,18 +71,18 @@ public final class RecipeTaskWidget implements DisplayWidget {
         Object text = this.task.recipes().size() == 1 ? this.titles.isEmpty() ? "" : this.titles.get(0) : isOpened ? "▼" : "▶";
         graphics.drawString(
             font,
-            this.title, x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            this.title, x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(desc, text), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(desc, text), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
         graphics.drawString(
             font,
-            progress, x + width - 5 - font.width(progress), y + 5, 0xFFFFFFFF,
+            progress, x + width - 5 - font.width(progress), y + 6, 0xFFFFFFFF,
             false
         );
 
@@ -103,7 +103,7 @@ public final class RecipeTaskWidget implements DisplayWidget {
             }
         }
 
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, actualY + height - font.lineHeight - 6, x + width - 5, actualY + height - 5, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, actualY + height - font.lineHeight - 5, x + width - 5, actualY + height - 6, this.task, this.progress);
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/StatTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/StatTaskWidget.java
@@ -28,17 +28,17 @@ public record StatTaskWidget(
         graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(DESCRIPTION, Component.translatable(task.stat().toLanguageKey("stat")), task.target()), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(DESCRIPTION, Component.translatable(task.stat().toLanguageKey("stat")), task.target()), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
         WidgetUtils.drawProgressText(graphics, x, y, width, this.task, this.progress);
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 5, x + width - 5, y + height - 6, this.task, this.progress);
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/StatTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/StatTaskWidget.java
@@ -22,26 +22,27 @@ public record StatTaskWidget(
     @Override
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         WidgetUtils.drawItemIcon(graphics, Items.SPYGLASS.getDefaultInstance(), x, y, iconSize);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(DESCRIPTION, Component.translatable(task.stat().toLanguageKey("stat")), task.target()), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(DESCRIPTION, Component.translatable(task.stat().toLanguageKey("stat")), task.target()), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
         WidgetUtils.drawProgressText(graphics, x, y, width, this.task, this.progress);
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 10, y + height - font.lineHeight + 2, x + width - 5, y + height - 2, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
     }
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/StructureTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/StructureTaskWidget.java
@@ -29,17 +29,18 @@ public final class StructureTaskWidget implements DisplayWidget {
     @Override
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         WidgetUtils.drawItemIcon(graphics, Items.STRUCTURE_BLOCK.getDefaultInstance(), x, y, iconSize);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            DESCRIPTION, x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            DESCRIPTION, x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
@@ -50,12 +51,12 @@ public final class StructureTaskWidget implements DisplayWidget {
         );
 
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 10, y + height - font.lineHeight + 2, x + width - 5, y + height - 2, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
     }
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/StructureTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/StructureTaskWidget.java
@@ -35,23 +35,23 @@ public final class StructureTaskWidget implements DisplayWidget {
         graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            DESCRIPTION, x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            DESCRIPTION, x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
         graphics.drawString(
             font,
-            progress, x + width - 5 - font.width(progress), y + 5, 0xFFFFFFFF,
+            progress, x + width - 5 - font.width(progress), y + 6, 0xFFFFFFFF,
             false
         );
 
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 5, x + width - 5, y + height - 6, this.task, this.progress);
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/XpTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/XpTaskWidget.java
@@ -43,26 +43,26 @@ public record XpTaskWidget(
 
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(desc, this.task.target(), this.task.xpType().text()), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(desc, this.task.target(), this.task.xpType().text()), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
         graphics.drawString(
             font,
-            progress, x + width - 5 - font.width(progress), y + 5, 0xFFFFFFFF,
+            progress, x + width - 5 - font.width(progress), y + 6, 0xFFFFFFFF,
             false
         );
 
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 5, x + width - 5, y + height - 6, this.task, this.progress);
 
         if (task.collectionType() == CollectionType.MANUAL) {
-            int buttonY = y + height - font.lineHeight - 17;
+            int buttonY = y + height - font.lineHeight - 16;
             int buttonWidth = font.width(ConstantComponents.Tasks.SUBMIT_XP);
             boolean buttonHovered = mouseX > x + width - 5 - buttonWidth && mouseX < x + width - 5 && mouseY > buttonY && mouseY < buttonY + font.lineHeight;
 
@@ -76,7 +76,7 @@ public record XpTaskWidget(
     public boolean mouseClicked(double mouseX, double mouseY, int mouseButton, int width) {
         if (task.collectionType() == CollectionType.MANUAL && !progress.isComplete()) {
             Font font = Minecraft.getInstance().font;
-            int buttonY = getHeight(width) - font.lineHeight - 17;
+            int buttonY = getHeight(width) - font.lineHeight - 16;
             int buttonWidth = font.width(ConstantComponents.Tasks.SUBMIT_XP);
             boolean buttonHovered = mouseX > width - 5 - buttonWidth && mouseX < width - 5 && mouseY > buttonY && mouseY < buttonY + font.lineHeight;
             if (buttonHovered) {

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/XpTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/XpTaskWidget.java
@@ -9,7 +9,6 @@ import earth.terrarium.heracles.api.client.WidgetUtils;
 import earth.terrarium.heracles.api.tasks.CollectionType;
 import earth.terrarium.heracles.api.tasks.QuestTaskDisplayFormatter;
 import earth.terrarium.heracles.api.tasks.client.display.TaskTitleFormatter;
-import earth.terrarium.heracles.api.tasks.defaults.GatherItemTask;
 import earth.terrarium.heracles.api.tasks.defaults.XpTask;
 import earth.terrarium.heracles.common.constants.ConstantComponents;
 import earth.terrarium.heracles.common.handlers.progress.TaskProgress;
@@ -29,24 +28,27 @@ public record XpTaskWidget(
 
     private static final String DESC_SINGULAR = "task.heracles.xp.desc.singular";
     private static final String DESC_PLURAL = "task.heracles.xp.desc.plural";
+    private static final String DESC_SUBMIT_SINGULAR = "task.heracles.xp.desc.submit.singular";
+    private static final String DESC_SUBMIT_PLURAL = "task.heracles.xp.desc.submit.plural";
 
     @Override
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         WidgetUtils.drawItemIcon(graphics, Items.EXPERIENCE_BOTTLE.getDefaultInstance(), x, y, iconSize);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
 
-        String desc = this.task.target() == 1 ? DESC_SINGULAR : DESC_PLURAL;
+        String desc = task.collectionType() == CollectionType.AUTOMATIC ? (this.task.target() == 1 ? DESC_SINGULAR : DESC_PLURAL) : (this.task.target() == 1 ? DESC_SUBMIT_SINGULAR : DESC_SUBMIT_PLURAL);
 
         graphics.drawString(
             font,
-            TaskTitleFormatter.create(this.task), x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            TaskTitleFormatter.create(this.task), x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(desc, this.task.target(), this.task.xpType().text()), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(desc, this.task.target(), this.task.xpType().text()), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
         String progress = QuestTaskDisplayFormatter.create(this.task, this.progress);
@@ -57,15 +59,15 @@ public record XpTaskWidget(
         );
 
         int height = getHeight(width);
-        WidgetUtils.drawProgressBar(graphics, x + iconSize + 10, y + height - font.lineHeight + 2, x + width - 5, y + height - 2, this.task, this.progress);
+        WidgetUtils.drawProgressBar(graphics, x + iconSize + 16, y + height - font.lineHeight - 6, x + width - 5, y + height - 5, this.task, this.progress);
 
         if (task.collectionType() == CollectionType.MANUAL) {
-            int buttonY = y + height - font.lineHeight - 10;
-            int buttonWidth = font.width(ConstantComponents.Tasks.CHECK);
-            boolean buttonHovered = mouseX > x + width - 2 - buttonWidth && mouseX < x + width - 2 && mouseY > buttonY && mouseY < buttonY + font.lineHeight;
+            int buttonY = y + height - font.lineHeight - 17;
+            int buttonWidth = font.width(ConstantComponents.Tasks.SUBMIT_XP);
+            boolean buttonHovered = mouseX > x + width - 5 - buttonWidth && mouseX < x + width - 5 && mouseY > buttonY && mouseY < buttonY + font.lineHeight;
 
-            Component text = buttonHovered ? ConstantComponents.Tasks.CHECK.copy().withStyle(ChatFormatting.UNDERLINE) : ConstantComponents.Tasks.CHECK;
-            graphics.drawString(font, text, x + width - 2 - buttonWidth, buttonY, this.progress.isComplete() ? 0xFF707070 : 0xFFD0D0D0, false);
+            Component text = buttonHovered ? ConstantComponents.Tasks.SUBMIT_XP.copy().withStyle(ChatFormatting.UNDERLINE) : ConstantComponents.Tasks.SUBMIT_XP;
+            graphics.drawString(font, text, x + width - 5 - buttonWidth, buttonY, this.progress.isComplete() ? 0xFF707070 : 0xFFD0D0D0, false);
             CursorUtils.setCursor(buttonHovered, this.progress.isComplete() ? CursorScreen.Cursor.DISABLED : CursorScreen.Cursor.POINTER);
         }
     }
@@ -74,13 +76,14 @@ public record XpTaskWidget(
     public boolean mouseClicked(double mouseX, double mouseY, int mouseButton, int width) {
         if (task.collectionType() == CollectionType.MANUAL && !progress.isComplete()) {
             Font font = Minecraft.getInstance().font;
-            int buttonY = getHeight(width) - 19;
-            boolean buttonHovered = mouseX > width - 2 - font.width(ConstantComponents.Tasks.CHECK) && mouseX < width - 2 && mouseY > buttonY && mouseY < buttonY + font.lineHeight;
+            int buttonY = getHeight(width) - font.lineHeight - 17;
+            int buttonWidth = font.width(ConstantComponents.Tasks.SUBMIT_XP);
+            boolean buttonHovered = mouseX > width - 5 - buttonWidth && mouseX < width - 5 && mouseY > buttonY && mouseY < buttonY + font.lineHeight;
             if (buttonHovered) {
                 NetworkHandler.CHANNEL.sendToServer(new ManualXpTaskPacket(this.quest, this.task.id()));
 
                 if (Minecraft.getInstance().player != null) {
-                    this.progress.addProgress(GatherItemTask.TYPE, task, Pair.of(Minecraft.getInstance().player, XpTask.Cause.MANUALLY_COMPLETED));
+                    this.progress.addProgress(XpTask.TYPE, task, Pair.of(Minecraft.getInstance().player, XpTask.Cause.MANUALLY_COMPLETED));
                 }
                 return true;
             }
@@ -90,6 +93,6 @@ public record XpTaskWidget(
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/display/TaskTitleFormatters.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/display/TaskTitleFormatters.java
@@ -30,7 +30,7 @@ public class TaskTitleFormatters {
         TaskTitleFormatter.register(EntityInteractTask.TYPE, (task) -> Component.translatable(toTranslationKey(task, true), task.entity().getDisplayName(EntityType::getDescription)));
         TaskTitleFormatter.register(CheckTask.TYPE, (task) -> Component.translatable(toTranslationKey(task, true)));
         TaskTitleFormatter.register(DummyTask.TYPE, (task) -> task.title() == null ? CommonComponents.EMPTY : task.title());
-        TaskTitleFormatter.register(XpTask.TYPE, (task) -> Component.translatable(toTranslationKey(task, true)));
+        TaskTitleFormatter.register(XpTask.TYPE, (task) -> Component.translatable(toTranslationKey(task, task.collectionType() == CollectionType.AUTOMATIC)));
         TaskTitleFormatter.register(LocationTask.TYPE, LocationTask::title);
         TaskTitleFormatter.register(StatTask.TYPE, (task) -> Component.translatable(toTranslationKey(task, true), Component.translatable(task.stat().toLanguageKey("stat")), task.target()));
         TaskTitleFormatter.register(CompositeTask.TYPE, (task) -> {

--- a/common/src/main/java/earth/terrarium/heracles/client/compat/rei/HearclesFavoriteEntry.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/compat/rei/HearclesFavoriteEntry.java
@@ -2,6 +2,7 @@ package earth.terrarium.heracles.client.compat.rei;
 
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.Lifecycle;
+import com.teamresourceful.resourcefullib.client.CloseablePoseStack;
 import earth.terrarium.heracles.Heracles;
 import earth.terrarium.heracles.client.HeraclesClient;
 import me.shedaniel.math.Rectangle;
@@ -33,11 +34,11 @@ public class HearclesFavoriteEntry extends FavoriteEntry {
         return new Renderer() {
             @Override
             public void render(GuiGraphics graphics, Rectangle bounds, int mouseX, int mouseY, float delta) {
-                graphics.pose().pushPose();
-                graphics.pose().translate(bounds.getCenterX(), bounds.getCenterY(), 0);
-                graphics.pose().scale(bounds.getWidth() / 16f, bounds.getHeight() / 16f, 1);
-                graphics.blit(TEXTURE, -8, -8, 0, 0, 16, 16, 16, 16);
-                graphics.pose().popPose();
+                try (var pose = new CloseablePoseStack(graphics)) {
+                    pose.translate(bounds.getCenterX(), bounds.getCenterY(), 0);
+                    pose.scale(bounds.getWidth() / 16f, bounds.getHeight() / 16f, 1);
+                    graphics.blit(TEXTURE, -8, -8, 0, 0, 16, 16, 16, 16);
+                }
             }
 
             @Override

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/AddDisplayWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/AddDisplayWidget.java
@@ -34,6 +34,6 @@ public record AddDisplayWidget(Runnable onClicked) implements DisplayWidget {
 
     @Override
     public int getHeight(int width) {
-        return 40;
+        return 42;
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/rewards/QuestDependentWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/rewards/QuestDependentWidget.java
@@ -17,23 +17,24 @@ public record QuestDependentWidget(Quest quest) implements DisplayWidget {
     @Override
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         quest.display().icon().render(graphics, scissor, x + 5, y + 5, iconSize, iconSize);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            Component.translatable(TITLE, this.quest.display().title()), x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            Component.translatable(TITLE, this.quest.display().title()), x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            DESCRIPTION, x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            DESCRIPTION, x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
     }
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/rewards/QuestDependentWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/rewards/QuestDependentWidget.java
@@ -23,12 +23,12 @@ public record QuestDependentWidget(Quest quest) implements DisplayWidget {
         graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            Component.translatable(TITLE, this.quest.display().title()), x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            Component.translatable(TITLE, this.quest.display().title()), x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            DESCRIPTION, x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            DESCRIPTION, x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
     }

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/tasks/DependencyDisplayWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/tasks/DependencyDisplayWidget.java
@@ -17,23 +17,24 @@ public record DependencyDisplayWidget(Quest quest) implements DisplayWidget {
     @Override
     public void render(GuiGraphics graphics, ScissorBoxStack scissor, int x, int y, int width, int mouseX, int mouseY, boolean hovered, float partialTicks) {
         Font font = Minecraft.getInstance().font;
-        WidgetUtils.drawBackground(graphics, x, y, width);
-        int iconSize = (int) (width * 0.1f);
+        WidgetUtils.drawBackground(graphics, x, y, width, getHeight(width));
+        int iconSize = 32;
         quest.display().icon().render(graphics, scissor, x + 5, y + 5, iconSize, iconSize);
+        graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            TITLE, x + iconSize + 10, y + 5, 0xFFFFFFFF,
+            TITLE, x + iconSize + 16, y + 5, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(DESCRIPTION, this.quest.display().title()), x + iconSize + 10, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(DESCRIPTION, this.quest.display().title()), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
             false
         );
     }
 
     @Override
     public int getHeight(int width) {
-        return (int) (width * 0.1f) + 10;
+        return 42;
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/tasks/DependencyDisplayWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/tasks/DependencyDisplayWidget.java
@@ -23,12 +23,12 @@ public record DependencyDisplayWidget(Quest quest) implements DisplayWidget {
         graphics.fill(x + iconSize + 9, y + 5, x + iconSize + 10, y + getHeight(width) - 5, 0xFF909090);
         graphics.drawString(
             font,
-            TITLE, x + iconSize + 16, y + 5, 0xFFFFFFFF,
+            TITLE, x + iconSize + 16, y + 6, 0xFFFFFFFF,
             false
         );
         graphics.drawString(
             font,
-            Component.translatable(DESCRIPTION, this.quest.display().title()), x + iconSize + 16, y + 7 + font.lineHeight, 0xFF808080,
+            Component.translatable(DESCRIPTION, this.quest.display().title()), x + iconSize + 16, y + 8 + font.lineHeight, 0xFF808080,
             false
         );
     }

--- a/common/src/main/java/earth/terrarium/heracles/common/constants/ConstantComponents.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/constants/ConstantComponents.java
@@ -103,6 +103,9 @@ public final class ConstantComponents {
 
         @Translate("Submit Items")
         public static final Component SUBMIT = Component.translatable("gui.heracles.tasks.submit");
+
+        @Translate("Submit XP")
+        public static final Component SUBMIT_XP = Component.translatable("gui.heracles.tasks.submit.xp");
     }
 
     public static final class Rewards {

--- a/common/src/main/resources/assets/heracles/lang/en_us.json
+++ b/common/src/main/resources/assets/heracles/lang/en_us.json
@@ -42,6 +42,7 @@
     "gui.heracles.tasks.edit": "Edit Task",
     "gui.heracles.tasks.check": "Complete Task",
     "gui.heracles.tasks.submit": "Submit Items",
+    "gui.heracles.tasks.submit.xp": "Submit XP",
     "gui.heracles.quests.create": "Enter New Quest ID",
     "gui.heracles.quests.import": "Import Quests",
     "gui.heracles.quests.view": "View Quests",

--- a/common/src/main/resources/assets/heracles_tasks/lang/en_us.json
+++ b/common/src/main/resources/assets/heracles_tasks/lang/en_us.json
@@ -65,9 +65,12 @@
     "setting.heracles.entity_interaction.entity": "Entity:",
 
     "task.heracles.xp": "⭐ Experience",
-    "task.heracles.xp.title.singular": "Submit XP",
-    "task.heracles.xp.desc.singular": "Submit %s XP %s",
-    "task.heracles.xp.desc.plural": "Submit %s XP %ss",
+    "task.heracles.xp.title.singular": "Gather XP",
+    "task.heracles.xp.title.plural": "Submit XP",
+    "task.heracles.xp.desc.singular": "Gather %s XP %s",
+    "task.heracles.xp.desc.plural": "Gather %s XP %ss",
+    "task.heracles.xp.desc.submit.singular": "Submit %s XP %s",
+    "task.heracles.xp.desc.submit.plural": "Submit %s XP %ss",
 
     "task.heracles.item_interaction": "\uD83C\uDFA3 Item Interaction",
     "task.heracles.item_interaction.title.singular": "Interact: %s",


### PR DESCRIPTION
Closes #71

Makes the height of task and reward widgets a constant value, instead of expanding to 10% of width.
Scales non-entity icons to from 16 to 32. Fake item render helper is dusty as a result, will need cleaning on reuse.
Adjusts progress bar and submit items text to fit margins, and expands progress bar to be chunkier.
Adds a single-unit dividing line to the right of icons to avoid text clashing with certain item textures.
Fix translation keys for the newly added XP collection types because why not.

PR:

![image](https://github.com/terrarium-earth/Heracles/assets/55819817/5b3a2631-2b9a-4b2a-99b0-577cddcb0cdd)

Release:

![image](https://github.com/terrarium-earth/Heracles/assets/55819817/1b0112a5-2750-46f0-a42c-55e7ae1dac46)

PR 1440p:

![image](https://github.com/terrarium-earth/Heracles/assets/55819817/4ce5c817-26ab-42a4-84d8-0b5aa43d20ee)

Release 1440p:

![image](https://github.com/terrarium-earth/Heracles/assets/55819817/74efd5d0-0a78-44dd-89ba-6fbb65afea48)

