### PR TITLE
Improve GatherTask Reliability

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/defaults/GatherItemTask.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/defaults/GatherItemTask.java
@@ -64,7 +64,7 @@ public record GatherItemTask(
             }
             return storage().set(target());
         }
-        return progress;
+        return storage().set(amount);
     }
 
     private NumericTag manual(NumericTag progress, Container input) {

--- a/common/src/main/java/earth/terrarium/heracles/common/duck/SlotChangeAwareInventory.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/duck/SlotChangeAwareInventory.java
@@ -1,0 +1,5 @@
+package earth.terrarium.heracles.common.duck;
+
+public interface SlotChangeAwareInventory {
+    void heracles$setChangedSlot(int slot);
+}

--- a/common/src/main/java/earth/terrarium/heracles/mixins/common/InventoryMixin.java
+++ b/common/src/main/java/earth/terrarium/heracles/mixins/common/InventoryMixin.java
@@ -2,6 +2,7 @@ package earth.terrarium.heracles.mixins.common;
 
 import com.mojang.datafixers.util.Pair;
 import earth.terrarium.heracles.api.tasks.defaults.GatherItemTask;
+import earth.terrarium.heracles.common.duck.SlotChangeAwareInventory;
 import earth.terrarium.heracles.common.handlers.progress.QuestProgressHandler;
 import earth.terrarium.heracles.common.handlers.progress.QuestsProgress;
 import net.minecraft.server.level.ServerPlayer;
@@ -11,22 +12,48 @@ import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.Optional;
 
 @Mixin(Inventory.class)
-public class InventoryMixin {
+public abstract class InventoryMixin implements SlotChangeAwareInventory {
+    @Unique int heracles$changedSlot = -1;
+    @Unique ItemStack heracles$addedStack = null;
 
     @Shadow @Final public Player player;
 
-    @Inject(method = "add(ILnet/minecraft/world/item/ItemStack;)Z", at = @At("RETURN"))
-    private void heracles$addItem(int slot, ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
-        if (cir.getReturnValue() && this.player instanceof ServerPlayer serverPlayer) {
+    @Shadow public abstract ItemStack getItem(int slot);
+
+    @Unique private void heracles$testProgress(ItemStack stack) {
+        if (this.player instanceof ServerPlayer serverPlayer) {
             QuestsProgress progress = QuestProgressHandler.getProgress(serverPlayer.getServer(), serverPlayer.getUUID());
             progress.testAndProgressTaskType(serverPlayer, Pair.of(Optional.of(stack), serverPlayer.getInventory()), GatherItemTask.TYPE);
         }
+    }
+
+    @Inject(method = "add(ILnet/minecraft/world/item/ItemStack;)Z", at = @At("HEAD"))
+    private void heracles$addItemStack(int slot, ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
+        heracles$addedStack = stack.copy();
+    }
+
+    @Inject(method = "add(ILnet/minecraft/world/item/ItemStack;)Z", at = @At("RETURN"))
+    private void heracles$addItemTest(int slot, ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
+        if (heracles$addedStack != null) heracles$testProgress(heracles$addedStack);
+        heracles$addedStack = null;
+    }
+
+    @Inject(method = "setChanged", at = @At("RETURN"))
+    private void heracles$setChanged(CallbackInfo ci) {
+        if (heracles$changedSlot != -1) heracles$testProgress(this.getItem(heracles$changedSlot));
+    }
+
+    @Override
+    public void heracles$setChangedSlot(int slot) {
+        heracles$changedSlot = slot;
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/mixins/common/SlotMixin.java
+++ b/common/src/main/java/earth/terrarium/heracles/mixins/common/SlotMixin.java
@@ -1,0 +1,27 @@
+package earth.terrarium.heracles.mixins.common;
+
+import earth.terrarium.heracles.common.duck.SlotChangeAwareInventory;
+import net.minecraft.world.Container;
+import net.minecraft.world.inventory.Slot;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Slot.class)
+public class SlotMixin {
+    @Shadow @Final private int slot;
+    @Shadow @Final public Container container;
+
+    @Inject(method = "setChanged", at = @At("HEAD"))
+    public void provideSlotContext(CallbackInfo ci) {
+        if (this.container instanceof SlotChangeAwareInventory awareInventory) awareInventory.heracles$setChangedSlot(this.slot);
+    }
+
+    @Inject(method = "setChanged", at = @At("TAIL"))
+    public void clearSlotContext(CallbackInfo ci) {
+        if (this.container instanceof SlotChangeAwareInventory awareInventory) awareInventory.heracles$setChangedSlot(-1);
+    }
+}

--- a/common/src/main/resources/heracles-common.mixins.json
+++ b/common/src/main/resources/heracles-common.mixins.json
@@ -8,7 +8,8 @@
         "common.InventoryMixin",
         "common.PlayerListMixin",
         "common.ReloadableServerResourcesMixin",
-        "common.ServerPlayerMixin"
+        "common.ServerPlayerMixin",
+        "common.SlotMixin"
     ],
     "client": [
         "client.FontManagerAccessor",


### PR DESCRIPTION
Closes #67

Tldr - only picking up items off the floor worked, they only worked for the full amount, and odysseus was putting out counts as strings, bricking the tasks. we'll PR to odysseus later on if that isn't fixed by the time we're done with heracles.

https://github.com/terrarium-earth/Heracles/assets/55819817/890ba3ef-4f67-4625-b5c0-9ba6dc70f288

picking up, partial picking up, inventory transfers, and `/give` now work.

Inventory transfers were fixed by passing the index of changed slots to an injected inventory interface via a slot mixin, then mixing into setChanged. 

Partial picking up was fixed by just setting the value in storage regardless of whether the target is met.

`/give` was fixed by caching a copy of the stack at the start of `add()`, then using it at return. This means the stack is intact (it's cleared in many cases) and therefore can pass preliminary matching tests for tasks, but the inventory is in the correct post-add state.

