### PR TITLE
Update quest screen when client affects task or reward progress

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/client/handlers/ClientQuests.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/handlers/ClientQuests.java
@@ -58,6 +58,10 @@ public class ClientQuests {
         PROGRESS.putAll(progress);
     }
 
+    public static void mergeProgress(Map<String, QuestProgress> progress) {
+        PROGRESS.putAll(progress);
+    }
+
     private static QuestEntry addEntry(
         String key,
         Quest quest,

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/BaseQuestScreen.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/BaseQuestScreen.java
@@ -193,7 +193,7 @@ public abstract class BaseQuestScreen extends AbstractQuestScreen<QuestContent> 
 
     @Override
     public @NotNull Component getTitle() {
-        return content.progress().isComplete() ? Component.literal("✔ ").append(super.getTitle()).append(Component.literal(" ✔")) : super.getTitle();
+        return content.progress().isComplete() ? Component.translatable("gui.heracles.quest.title.complete", super.getTitle()) : super.getTitle();
     }
 
     public Quest quest() {

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/QuestEditScreen.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/QuestEditScreen.java
@@ -16,6 +16,7 @@ import earth.terrarium.heracles.client.widgets.modals.CreateObjectModal;
 import earth.terrarium.heracles.client.widgets.modals.EditObjectModal;
 import earth.terrarium.heracles.client.widgets.modals.icon.IconModal;
 import earth.terrarium.heracles.common.constants.ConstantComponents;
+import earth.terrarium.heracles.common.handlers.progress.QuestProgress;
 import earth.terrarium.heracles.common.handlers.quests.QuestHandler;
 import earth.terrarium.heracles.common.menus.quest.QuestContent;
 import earth.terrarium.heracles.common.network.NetworkHandler;
@@ -48,6 +49,13 @@ public class QuestEditScreen extends BaseQuestScreen {
 
     public QuestEditScreen(QuestContent content) {
         super(content);
+    }
+
+    @Override
+    public void updateProgress(@Nullable QuestProgress newProgress) {
+        super.updateProgress(newProgress);
+        this.taskList.update(this.quest().tasks().values());
+        this.rewardList.update(this.content.fromGroup(), this.content.id(), this.quest());
     }
 
     @Override
@@ -95,7 +103,6 @@ public class QuestEditScreen extends BaseQuestScreen {
                     .toList()
             );
         });
-        this.taskList.update(this.quest().tasks().values());
 
         this.rewardList = new RewardListWidget(
             contentX, contentY, contentWidth, contentHeight, this.entry(),
@@ -133,7 +140,6 @@ public class QuestEditScreen extends BaseQuestScreen {
             );
         }
         );
-        this.rewardList.update(this.content.fromGroup(), this.content.id(), this.quest());
 
         if (Minecraft.getInstance().player != null && Minecraft.getInstance().player.hasPermissions(2)) {
             addRenderableWidget(new ImageButton(this.width - 24, 1, 11, 11, 33, 15, 11, HEADING, 256, 256, (button) ->
@@ -154,6 +160,7 @@ public class QuestEditScreen extends BaseQuestScreen {
         }
 
         this.iconModal = addTemporary(new IconModal(this.width, this.height));
+        updateProgress(null);
     }
 
     private <T extends QuestTask<?, ?, T>> void taskPopup(QuestTaskType<T> type, String id, @Nullable T task, Consumer<T> consumer) {

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/QuestProgressWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/QuestProgressWidget.java
@@ -5,13 +5,28 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.network.chat.Component;
 
-public record QuestProgressWidget(int x, int y, int width, int tasks, int completed) implements Renderable {
-
-    private static final String TITLE_INCOMPLETE =  "gui.heracles.progress.title.incomplete";
-    private static final String TITLE_COMPLETE =  "gui.heracles.progress.title.complete";
+public final class QuestProgressWidget implements Renderable {
+    private static final String TITLE_INCOMPLETE = "gui.heracles.progress.title.incomplete";
+    private static final String TITLE_COMPLETE = "gui.heracles.progress.title.complete";
     private static final String DESC_SINGULAR = "gui.heracles.progress.desc.incomplete.singular";
     private static final String DESC_PLURAL = "gui.heracles.progress.desc.incomplete.plural";
     private static final String DESC_COMPLETE = "gui.heracles.progress.desc.complete";
+    private final int x;
+    private final int y;
+    private final int width;
+    private int tasks = 0;
+    private int completed = 0;
+
+    public QuestProgressWidget(int x, int y, int width) {
+        this.x = x;
+        this.y = y;
+        this.width = width;
+    }
+
+    public void update(int tasks, int completed) {
+        this.tasks = tasks;
+        this.completed = completed;
+    }
 
     @Override
     public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/QuestScreen.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/QuestScreen.java
@@ -1,8 +1,10 @@
 package earth.terrarium.heracles.client.screens.quest;
 
+import earth.terrarium.heracles.Heracles;
 import earth.terrarium.heracles.client.screens.quest.rewards.RewardListWidget;
 import earth.terrarium.heracles.client.screens.quest.tasks.TaskListWidget;
 import earth.terrarium.heracles.common.constants.ConstantComponents;
+import earth.terrarium.heracles.common.handlers.progress.QuestProgress;
 import earth.terrarium.heracles.common.menus.quest.QuestContent;
 import earth.terrarium.heracles.common.network.NetworkHandler;
 import earth.terrarium.heracles.common.network.packets.quests.OpenQuestPacket;
@@ -13,6 +15,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.ImageButton;
 import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.components.events.GuiEventListener;
+import org.jetbrains.annotations.Nullable;
 
 public class QuestScreen extends BaseQuestScreen {
 
@@ -21,9 +24,28 @@ public class QuestScreen extends BaseQuestScreen {
     private DocumentWidget description;
 
     private String descriptionError;
+    private String desc;
 
     public QuestScreen(QuestContent content) {
         super(content);
+    }
+
+    @Override
+    public void updateProgress(@Nullable QuestProgress newProgress) {
+        super.updateProgress(newProgress);
+        this.taskList.update(this.quest().tasks().values());
+        this.rewardList.update(this.content.fromGroup(), this.content.id(), this.quest());
+        // Completely recreate description in case of task/reward tags
+        // Can't touch hermes to make a better solution
+        int contentX = (int) (this.width * 0.31f);
+        int contentY = 30;
+        int contentWidth = (int) (this.width * 0.63f);
+        int contentHeight = this.height - 45;
+        if (this.overview == null) {
+            contentX = (int) ((this.width - contentWidth) / 2f);
+        }
+        TagProvider provider = new QuestTagProvider();
+        this.description = new DocumentWidget(contentX, contentY, contentWidth, contentHeight, new DefaultTheme(), provider.parse(desc));
     }
 
     @Override
@@ -37,32 +59,21 @@ public class QuestScreen extends BaseQuestScreen {
         if (this.overview == null) {
             contentX = (int) ((this.width - contentWidth) / 2f);
         }
-
         this.taskList = new TaskListWidget(contentX, contentY, contentWidth, contentHeight, this.content.id(), this.entry(), this.content.progress(), this.content.quests(), null, null);
-        this.taskList.update(this.quest().tasks().values());
-
         this.rewardList = new RewardListWidget(contentX, contentY, contentWidth, contentHeight, this.entry(), this.content.progress(), null, null);
-        this.rewardList.update(this.content.fromGroup(), this.content.id(), this.quest());
-
+        try {
+            this.descriptionError = null;
+            this.desc = String.join("", MarkdownParser.parse(this.quest().display().description()));
+        } catch (Throwable e) {
+            this.descriptionError = e.getMessage();
+            Heracles.LOGGER.error("Error parsing quest description: ", e);
+        }
         if (Minecraft.getInstance().player != null && Minecraft.getInstance().player.hasPermissions(2)) {
             addRenderableWidget(new ImageButton(this.width - 24, 1, 11, 11, 33, 15, 11, HEADING, 256, 256, (button) ->
                 NetworkHandler.CHANNEL.sendToServer(new OpenQuestPacket(this.content.fromGroup(), this.content.id(), true))
             )).setTooltip(Tooltip.create(ConstantComponents.TOGGLE_EDIT));
         }
-
-        try {
-            this.descriptionError = null;
-            TagProvider provider = new QuestTagProvider();
-            String desc = String.join("", MarkdownParser.parse(this.quest().display().description()));
-            this.description = new DocumentWidget(contentX, contentY, contentWidth, contentHeight, new DefaultTheme(), provider.parse(desc));
-        } catch (Throwable e) {
-            this.descriptionError = e.getMessage();
-            e.printStackTrace();
-            if (e.getCause() != null) {
-                e.getCause().printStackTrace();
-                System.out.println("Error parsing quest description: " + e.getCause().getMessage());
-            }
-        }
+        updateProgress(null);
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/tasks/TaskListWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/tasks/TaskListWidget.java
@@ -42,7 +42,6 @@ public class TaskListWidget extends AbstractContainerEventHandler implements Ren
     private final String questId;
     private final ClientQuests.QuestEntry entry;
     private final Map<String, ModUtils.QuestStatus> quests;
-    private final int tasksComplete;
 
     private final int x;
     private final int y;
@@ -63,7 +62,6 @@ public class TaskListWidget extends AbstractContainerEventHandler implements Ren
         Map<String, ModUtils.QuestStatus> quests, BiConsumer<QuestTask<?, ?, ?>, Boolean> onClick, Runnable onCreate
     ) {
         this.progress = progress;
-        this.tasksComplete = (int) entry.value().tasks().values().stream().filter(t -> progress.getTask(t).isComplete()).count();
         this.quests = quests;
         this.questId = questId;
         this.entry = entry;
@@ -99,7 +97,7 @@ public class TaskListWidget extends AbstractContainerEventHandler implements Ren
             }
         }
         this.widgets.clear();
-        this.widgets.add(new MutablePair<>(null, new TaskListHeadingWidget(this.entry.value().tasks().size(), this.tasksComplete)));
+        this.widgets.add(new MutablePair<>(null, new TaskListHeadingWidget(this.entry.value().tasks().size(), (int) entry.value().tasks().values().stream().filter(t -> progress.getTask(t).isComplete()).count())));
         if (!dependencies.isEmpty()) {
             this.widgets.add(new MutablePair<>(null, DEPENDENCIES));
             this.widgets.addAll(dependencies);

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/tasks/TaskListWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/tasks/TaskListWidget.java
@@ -97,7 +97,7 @@ public class TaskListWidget extends AbstractContainerEventHandler implements Ren
             }
         }
         this.widgets.clear();
-        this.widgets.add(new MutablePair<>(null, new TaskListHeadingWidget(this.entry.value().tasks().size(), (int) entry.value().tasks().values().stream().filter(t -> progress.getTask(t).isComplete()).count())));
+        this.widgets.add(new MutablePair<>(null, new TaskListHeadingWidget(tasks.size(), (int) tasks.stream().filter(t -> progress.getTask(t).isComplete()).count())));
         if (!dependencies.isEmpty()) {
             this.widgets.add(new MutablePair<>(null, DEPENDENCIES));
             this.widgets.addAll(dependencies);

--- a/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/QuestProgress.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/QuestProgress.java
@@ -44,6 +44,10 @@ public class QuestProgress {
                 tasks.put(task.id(), new TaskProgress<>(task));
             }
         }
+        checkComplete();
+    }
+
+    public void checkComplete() {
         for (TaskProgress<?> task : tasks.values()) {
             if (!task.isComplete()) {
                 return;

--- a/common/src/main/java/earth/terrarium/heracles/common/network/NetworkHandler.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/network/NetworkHandler.java
@@ -29,6 +29,7 @@ public class NetworkHandler {
         CHANNEL.registerPacket(NetworkDirection.SERVER_TO_CLIENT, SyncQuestsPacket.ID, SyncQuestsPacket.HANDLER, SyncQuestsPacket.class);
         CHANNEL.registerPacket(NetworkDirection.SERVER_TO_CLIENT, QuestCompletedPacket.ID, QuestCompletedPacket.HANDLER, QuestCompletedPacket.class);
         CHANNEL.registerPacket(NetworkDirection.SERVER_TO_CLIENT, SyncPinnedQuestsPacket.ID, SyncPinnedQuestsPacket.HANDLER, SyncPinnedQuestsPacket.class);
+        CHANNEL.registerPacket(NetworkDirection.SERVER_TO_CLIENT, SyncQuestProgressPacket.ID, SyncQuestProgressPacket.HANDLER, SyncQuestProgressPacket.class);
         CHANNEL.registerPacket(NetworkDirection.SERVER_TO_CLIENT, SyncDescriptionsPacket.ID, SyncDescriptionsPacket.HANDLER, SyncDescriptionsPacket.class);
         CHANNEL.registerPacket(NetworkDirection.SERVER_TO_CLIENT, OpenQuestScreenPacket.ID, OpenQuestScreenPacket.HANDLER, OpenQuestScreenPacket.class);
         CHANNEL.registerPacket(NetworkDirection.SERVER_TO_CLIENT, OpenQuestsScreenPacket.ID, OpenQuestsScreenPacket.HANDLER, OpenQuestsScreenPacket.class);

--- a/common/src/main/java/earth/terrarium/heracles/common/network/packets/quests/SyncQuestProgressPacket.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/network/packets/quests/SyncQuestProgressPacket.java
@@ -1,0 +1,66 @@
+package earth.terrarium.heracles.common.network.packets.quests;
+
+import com.teamresourceful.resourcefullib.common.networking.base.Packet;
+import com.teamresourceful.resourcefullib.common.networking.base.PacketContext;
+import com.teamresourceful.resourcefullib.common.networking.base.PacketHandler;
+import earth.terrarium.heracles.Heracles;
+import earth.terrarium.heracles.client.handlers.ClientQuests;
+import earth.terrarium.heracles.client.screens.quest.BaseQuestScreen;
+import earth.terrarium.heracles.common.handlers.progress.QuestProgress;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public record SyncQuestProgressPacket(Map<String, QuestProgress> quests) implements Packet<SyncQuestProgressPacket> {
+    public static final ResourceLocation ID = new ResourceLocation(Heracles.MOD_ID, "sync_quest_progress");
+    public static final PacketHandler<SyncQuestProgressPacket> HANDLER = new Handler();
+
+    @Override
+    public ResourceLocation getID() {
+        return ID;
+    }
+
+    @Override
+    public PacketHandler<SyncQuestProgressPacket> getHandler() {
+        return HANDLER;
+    }
+
+    public static class Handler implements PacketHandler<SyncQuestProgressPacket> {
+
+        @Override
+        public void encode(SyncQuestProgressPacket message, FriendlyByteBuf buffer) {
+            buffer.writeVarInt(message.quests.size());
+            for (var entry : message.quests.entrySet()) {
+                buffer.writeUtf(entry.getKey());
+                buffer.writeNbt(entry.getValue().save());
+            }
+        }
+
+        @Override
+        public SyncQuestProgressPacket decode(FriendlyByteBuf buffer) {
+            Map<String, QuestProgress> quests = new LinkedHashMap<>();
+            int size = buffer.readVarInt();
+            for (int i = 0; i < size; i++) {
+                String quest = buffer.readUtf();
+                ClientQuests.get(quest).ifPresent(entry -> {
+                    QuestProgress progress = new QuestProgress(entry.value(), buffer.readNbt());
+                    quests.put(quest, progress);
+                });
+            }
+            return new SyncQuestProgressPacket(quests);
+        }
+
+        @Override
+        public PacketContext handle(SyncQuestProgressPacket message) {
+            return (player, level) -> {
+                ClientQuests.mergeProgress(message.quests);
+                if (Minecraft.getInstance().screen instanceof BaseQuestScreen screen) {
+                    screen.updateProgress(message.quests.getOrDefault(screen.getQuestId(), null));
+                }
+            };
+        }
+    }
+}

--- a/common/src/main/java/earth/terrarium/heracles/common/network/packets/rewards/ClaimRewardsPacket.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/network/packets/rewards/ClaimRewardsPacket.java
@@ -5,10 +5,13 @@ import com.teamresourceful.resourcefullib.common.networking.base.PacketContext;
 import com.teamresourceful.resourcefullib.common.networking.base.PacketHandler;
 import earth.terrarium.heracles.Heracles;
 import earth.terrarium.heracles.api.quests.Quest;
+import earth.terrarium.heracles.common.handlers.progress.QuestProgressHandler;
 import earth.terrarium.heracles.common.handlers.quests.QuestHandler;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Set;
 
 public record ClaimRewardsPacket(String quest, String reward) implements Packet<ClaimRewardsPacket> {
     public static final ResourceLocation ID = new ResourceLocation(Heracles.MOD_ID, "claim_rewards");
@@ -51,6 +54,7 @@ public record ClaimRewardsPacket(String quest, String reward) implements Packet<
                     } else {
                         quest.claimAllowedReward((ServerPlayer) player, message.quest, message.reward);
                     }
+                    QuestProgressHandler.sync((ServerPlayer) player, Set.of(message.quest));
                 }
             };
         }

--- a/common/src/main/java/earth/terrarium/heracles/common/network/packets/rewards/ClaimSelectableRewardsPacket.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/network/packets/rewards/ClaimSelectableRewardsPacket.java
@@ -18,6 +18,7 @@ import net.minecraft.server.level.ServerPlayer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.Set;
 
 public record ClaimSelectableRewardsPacket(
     String quest, String reward, Collection<String> rewards
@@ -74,6 +75,7 @@ public record ClaimSelectableRewardsPacket(
                                         .map(selectableReward.rewards()::get)
                                         .filter(Objects::nonNull)
                                 );
+                                QuestProgressHandler.sync((ServerPlayer) player, Set.of(message.quest));
                             }
                         }
                     }

--- a/common/src/main/java/earth/terrarium/heracles/common/network/packets/tasks/CheckTaskPacket.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/network/packets/tasks/CheckTaskPacket.java
@@ -10,6 +10,8 @@ import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 
+import java.util.Set;
+
 public record CheckTaskPacket(String quest, String task) implements Packet<CheckTaskPacket> {
     public static final ResourceLocation ID = new ResourceLocation(Heracles.MOD_ID, "check_task");
     public static final PacketHandler<CheckTaskPacket> HANDLER = new Handler();
@@ -43,6 +45,7 @@ public record CheckTaskPacket(String quest, String task) implements Packet<Check
                 if (player instanceof ServerPlayer serverPlayer) {
                     QuestProgressHandler.getProgress(serverPlayer.getServer(), player.getUUID())
                         .testAndProgressTask(serverPlayer, message.quest, message.task, null, CheckTask.TYPE);
+                    QuestProgressHandler.sync(serverPlayer, Set.of(message.quest));
                 }
             };
         }

--- a/common/src/main/resources/assets/heracles/lang/en_us.json
+++ b/common/src/main/resources/assets/heracles/lang/en_us.json
@@ -24,6 +24,7 @@
 
     "gui.heracles.pinned_quests": "Pinned Quests",
     "gui.heracles.pinned_quests.move": "Move Pinned Quests",
+    "gui.heracles.quest.title.complete": "✔ %s ✔",
     "gui.heracles.progress.title.incomplete": "Incomplete",
     "gui.heracles.progress.title.complete": "Complete",
     "gui.heracles.progress.desc.incomplete.singular": "%s Task Remaining",


### PR DESCRIPTION
closes #68 

Adds systems by which the QuestScreens (QuestScreen and QuestEditScreen) can be updated with new progress, along with relevant packets, helpers, etc. Uses this for checkbox task completion, and reward claiming.

Modelled off of the way pinned quests does it, adapted for use.

Swapped out a few println's while i was at it.

https://github.com/terrarium-earth/Heracles/assets/55819817/ab21f0a1-d1af-484f-87b7-d2370ff5db98

