### PR TITLE
Centre quests screen on open, use fixed-size scrollbars

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsScreen.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsScreen.java
@@ -31,11 +31,6 @@ public class QuestsScreen extends AbstractQuestScreen<QuestsContent> {
     public QuestsScreen(QuestsContent content) {
         super(content, CommonComponents.EMPTY);
         this.hasBackButton = false;
-        if (!HeraclesClient.lastGroup.equalsIgnoreCase(content.group())) {
-            QuestsWidget.offset.set(0, 0);
-        }
-
-        HeraclesClient.lastGroup = content.group();
     }
 
     @Override
@@ -74,6 +69,7 @@ public class QuestsScreen extends AbstractQuestScreen<QuestsContent> {
             }
         ));
         questsWidget.update(this.content, quests);
+        HeraclesClient.lastGroup = content.group();
 
         this.groupsList = addRenderableWidget(new GroupsList(
             0,


### PR DESCRIPTION
Closes #40 (though not in the way it was originally requested)

https://github.com/terrarium-earth/Heracles/assets/55819817/c8da8e80-cc73-4815-a33f-571c5f8e0280

Offset always starts at the dead centre of the allowed offset values. This is a good happy medium between using 0,0 and attempting to perform a more advanced heuristic on quest types.

As the editor improves, making this configurable so that modpack devs can use 0,0 again would make sense - but right now without zooming or grid snapping or being able to offset the positions of an entire group, this makes sense I think.

Also the scrollbars were busted before I touched anything, so i went in and rewrote them as fixed-width ones, as that's what i'm familiar with.