### PR TITLE
Granular quest hidden per status

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/api/quests/QuestSettings.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/quests/QuestSettings.java
@@ -2,20 +2,15 @@ package earth.terrarium.heracles.api.quests;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import com.teamresourceful.resourcefullib.common.codecs.CodecExtras;
 import com.teamresourceful.resourcefullib.common.codecs.EnumCodec;
 import earth.terrarium.heracles.common.utils.ModUtils;
 
 import java.util.Objects;
 
 public final class QuestSettings {
-    private static final Codec<ModUtils.QuestStatus> LEGACY_HIDDEN_CODEC = Codec.BOOL.orElse(false).xmap(b -> b ? ModUtils.QuestStatus.IN_PROGRESS : ModUtils.QuestStatus.LOCKED, s -> s != ModUtils.QuestStatus.IN_PROGRESS);
-    private static final Codec<ModUtils.QuestStatus> HIDDEN_CODEC = CodecExtras.eitherLeft(Codec.either(EnumCodec.of(ModUtils.QuestStatus.class).orElse(ModUtils.QuestStatus.LOCKED), LEGACY_HIDDEN_CODEC));
-
-
     public static final Codec<QuestSettings> CODEC = RecordCodecBuilder.create(instance -> instance.group(
         Codec.BOOL.fieldOf("individual_progress").orElse(false).forGetter(QuestSettings::individualProgress),
-        HIDDEN_CODEC.fieldOf("hidden").orElse(ModUtils.QuestStatus.LOCKED).forGetter(QuestSettings::hiddenUntil),
+        EnumCodec.of(ModUtils.QuestStatus.class).orElse(ModUtils.QuestStatus.LOCKED).fieldOf("hidden").forGetter(QuestSettings::hiddenUntil),
         Codec.BOOL.fieldOf("unlockNotification").orElse(false).forGetter(QuestSettings::unlockNotification),
         Codec.BOOL.fieldOf("showDependencyArrow").orElse(true).forGetter(QuestSettings::showDependencyArrow)
     ).apply(instance, QuestSettings::new));

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestSettingsInitalizer.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestSettingsInitalizer.java
@@ -2,7 +2,9 @@ package earth.terrarium.heracles.client.screens.quests;
 
 import earth.terrarium.heracles.api.client.settings.SettingInitializer;
 import earth.terrarium.heracles.api.client.settings.base.BooleanSetting;
+import earth.terrarium.heracles.api.client.settings.base.EnumSetting;
 import earth.terrarium.heracles.api.quests.QuestSettings;
+import earth.terrarium.heracles.common.utils.ModUtils;
 import org.jetbrains.annotations.Nullable;
 
 public class QuestSettingsInitalizer implements SettingInitializer<QuestSettings> {
@@ -13,7 +15,7 @@ public class QuestSettingsInitalizer implements SettingInitializer<QuestSettings
     public CreationData create(@Nullable QuestSettings object) {
         CreationData settings = new CreationData();
         settings.put("individual_progress", BooleanSetting.FALSE, object != null && object.individualProgress());
-        settings.put("hidden", BooleanSetting.FALSE, object != null && object.hidden());
+        settings.put("hidden", new EnumSetting<>(ModUtils.QuestStatus.class, ModUtils.QuestStatus.LOCKED), object != null ? object.hiddenUntil() : ModUtils.QuestStatus.LOCKED);
         settings.put("unlock_notification", BooleanSetting.FALSE, object != null && object.unlockNotification());
         settings.put("show_dependency_arrow", BooleanSetting.TRUE, object != null && object.showDependencyArrow());
         return settings;
@@ -23,7 +25,7 @@ public class QuestSettingsInitalizer implements SettingInitializer<QuestSettings
     public QuestSettings create(String id, QuestSettings object, Data data) {
         return new QuestSettings(
             data.get("individual_progress", BooleanSetting.FALSE).orElse(object != null && object.individualProgress()),
-            data.get("hidden", BooleanSetting.FALSE).orElse(object != null && object.hidden()),
+            data.get("hidden", new EnumSetting<>(ModUtils.QuestStatus.class, ModUtils.QuestStatus.LOCKED)).orElse(object != null ? object.hiddenUntil() : ModUtils.QuestStatus.LOCKED),
             data.get("unlock_notification", BooleanSetting.FALSE).orElse(object != null && object.unlockNotification()),
             data.get("show_dependency_arrow", BooleanSetting.TRUE).orElse(object != null && object.showDependencyArrow())
         );

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
@@ -143,7 +143,9 @@ public class QuestsWidget extends BaseWidget {
         var value = quest.value();
         boolean inGroup = value.display().groups().containsKey(group);
         if (!inGroup) return true;
-        if (value.settings().hidden()) {
+        if (value.settings().hiddenUntil() == ModUtils.QuestStatus.COMPLETED) {
+            return !statuses.getBoolean(quest.key());
+        } else if (value.settings().hiddenUntil() == ModUtils.QuestStatus.IN_PROGRESS) {
             for (var dependency : quest.dependencies()) {
                 if (!statuses.getBoolean(dependency.key())) {
                     return true;

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quests/SelectQuestWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quests/SelectQuestWidget.java
@@ -145,7 +145,7 @@ public class SelectQuestWidget extends BaseWidget {
                             QuestSettings questSettings = QuestSettingsInitalizer.INSTANCE.create("quest", settings, data);
                             return NetworkQuestData.builder()
                                 .individualProgress(questSettings.individualProgress())
-                                .hidden(questSettings.hidden())
+                                .hiddenUntil(questSettings.hiddenUntil())
                                 .unlockNotification(questSettings.unlockNotification())
                                 .showDependencyArrow(questSettings.showDependencyArrow());
                         })

--- a/common/src/main/java/earth/terrarium/heracles/common/network/packets/quests/data/NetworkQuestData.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/network/packets/quests/data/NetworkQuestData.java
@@ -10,6 +10,7 @@ import earth.terrarium.heracles.api.rewards.QuestReward;
 import earth.terrarium.heracles.api.rewards.QuestRewards;
 import earth.terrarium.heracles.api.tasks.QuestTask;
 import earth.terrarium.heracles.api.tasks.QuestTasks;
+import earth.terrarium.heracles.common.utils.ModUtils;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import org.joml.Vector2i;
@@ -64,7 +65,7 @@ public record NetworkQuestData(
         private List<String> description;
         private Map<String, GroupDisplay> groups;
         private TriState individualProgress = TriState.UNDEFINED;
-        private TriState hidden = TriState.UNDEFINED;
+        private ModUtils.QuestStatus hiddenUntil = null;
         private TriState unlockNotification = TriState.UNDEFINED;
         private TriState showDependencyArrow = TriState.UNDEFINED;
         private Set<String> dependencies;
@@ -116,8 +117,8 @@ public record NetworkQuestData(
             return this;
         }
 
-        public Builder hidden(boolean hidden) {
-            this.hidden = TriState.of(hidden);
+        public Builder hiddenUntil(ModUtils.QuestStatus hiddenUntil) {
+            this.hiddenUntil = hiddenUntil;
             return this;
         }
 
@@ -159,10 +160,10 @@ public record NetworkQuestData(
                 );
             }
             NetworkQuestSettingsData settings = null;
-            if (individualProgress != TriState.UNDEFINED || hidden != TriState.UNDEFINED || unlockNotification != TriState.UNDEFINED) {
+            if (individualProgress != TriState.UNDEFINED || hiddenUntil != null || unlockNotification != TriState.UNDEFINED) {
                 settings = new NetworkQuestSettingsData(
                     Optional.ofNullable(individualProgress.isUndefined() ? null : individualProgress.isTrue()),
-                    Optional.ofNullable(hidden.isUndefined() ? null : hidden.isTrue()),
+                    Optional.ofNullable(hiddenUntil),
                     Optional.ofNullable(unlockNotification.isUndefined() ? null : unlockNotification.isTrue()),
                     Optional.ofNullable(showDependencyArrow.isUndefined() ? null : showDependencyArrow.isTrue())
                 );

--- a/common/src/main/java/earth/terrarium/heracles/common/network/packets/quests/data/NetworkQuestSettingsData.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/network/packets/quests/data/NetworkQuestSettingsData.java
@@ -4,19 +4,20 @@ import com.teamresourceful.bytecodecs.base.ByteCodec;
 import com.teamresourceful.bytecodecs.base.object.ObjectByteCodec;
 import earth.terrarium.heracles.api.quests.Quest;
 import earth.terrarium.heracles.api.quests.QuestSettings;
+import earth.terrarium.heracles.common.utils.ModUtils;
 
 import java.util.Optional;
 
 public record NetworkQuestSettingsData(
     Optional<Boolean> individualProgress,
-    Optional<Boolean> hidden,
+    Optional<ModUtils.QuestStatus> hiddenUntil,
     Optional<Boolean> unlockNotification,
     Optional<Boolean> showDependencyArrow
 ) {
 
     public static final ByteCodec<NetworkQuestSettingsData> CODEC = ObjectByteCodec.create(
         ByteCodec.BOOLEAN.optionalFieldOf(NetworkQuestSettingsData::individualProgress),
-        ByteCodec.BOOLEAN.optionalFieldOf(NetworkQuestSettingsData::hidden),
+        ByteCodec.ofEnum(ModUtils.QuestStatus.class).optionalFieldOf(NetworkQuestSettingsData::hiddenUntil),
         ByteCodec.BOOLEAN.optionalFieldOf(NetworkQuestSettingsData::unlockNotification),
         ByteCodec.BOOLEAN.optionalFieldOf(NetworkQuestSettingsData::showDependencyArrow),
         NetworkQuestSettingsData::new
@@ -25,7 +26,7 @@ public record NetworkQuestSettingsData(
     public void update(Quest quest) {
         QuestSettings settings = quest.settings();
         individualProgress.ifPresent(settings::setIndividualProgress);
-        hidden.ifPresent(settings::setHidden);
+        hiddenUntil.ifPresent(settings::setHiddenUntil);
         unlockNotification.ifPresent(settings::setUnlockNotification);
         showDependencyArrow.ifPresent(settings::setShowDependencyArrow);
     }

--- a/common/src/main/java/earth/terrarium/heracles/common/utils/ModUtils.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/utils/ModUtils.java
@@ -25,6 +25,8 @@ import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.TagKey;
+import net.minecraft.util.StringRepresentable;
+import org.jetbrains.annotations.NotNull;
 import org.joml.Vector2i;
 
 import java.util.HashMap;
@@ -125,10 +127,15 @@ public class ModUtils {
         return quests;
     }
 
-    public enum QuestStatus {
+    public enum QuestStatus implements StringRepresentable {
         COMPLETED,
         IN_PROGRESS,
-        LOCKED
+        LOCKED;
+
+        @Override
+        public @NotNull String getSerializedName() {
+            return this.name();
+        }
     }
 
     public static String findAvailableFolderName(String folderName) {

--- a/common/src/main/java/earth/terrarium/heracles/common/utils/ModUtils.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/utils/ModUtils.java
@@ -129,9 +129,9 @@ public class ModUtils {
     }
 
     public enum QuestStatus implements StringRepresentable {
-        COMPLETED,
+        LOCKED,
         IN_PROGRESS,
-        LOCKED;
+        COMPLETED;
 
         @Override
         public @NotNull String getSerializedName() {

--- a/common/src/main/java/earth/terrarium/heracles/common/utils/ModUtils.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/utils/ModUtils.java
@@ -31,6 +31,7 @@ import org.joml.Vector2i;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -134,7 +135,7 @@ public class ModUtils {
 
         @Override
         public @NotNull String getSerializedName() {
-            return this.name();
+            return "quest.heracles.%s".formatted(name().toLowerCase(Locale.ROOT));
         }
     }
 

--- a/common/src/main/resources/assets/heracles/lang/en_us.json
+++ b/common/src/main/resources/assets/heracles/lang/en_us.json
@@ -66,7 +66,7 @@
     "gui.heracles.open_quest_file": "Open Quest File",
 
     "setting.heracles.quest.individual_progress": "Individual Progress",
-    "setting.heracles.quest.hidden": "Prerequisite Hidden",
+    "setting.heracles.quest.hidden": "Hidden Until",
     "setting.heracles.quest.unlock_notification": "Unlock Notification",
     "setting.heracles.quest.show_dependency_arrow": "Show Dependency Arrow",
 


### PR DESCRIPTION
Closes #102 

Changes `hidden` to be a QuestStatus representing the first state at which the quest should be visible. Renamed to `hiddenUntil` in code to better reflect this.

This means that `hidden: "COMPLETED"` matches FTB's old `invisible` property. current `true` becomes `IN_PROGRESS`, and false and undefined are now equivalent to `LOCKED`.