### PR TITLE
Add toast wrapping

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/client/toasts/QuestCompletedToast.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/toasts/QuestCompletedToast.java
@@ -2,6 +2,7 @@ package earth.terrarium.heracles.client.toasts;
 
 import com.teamresourceful.resourcefullib.client.scissor.ScissorBoxStack;
 import earth.terrarium.heracles.api.quests.Quest;
+import earth.terrarium.heracles.api.quests.QuestIcon;
 import earth.terrarium.heracles.client.handlers.ClientQuests;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.toasts.Toast;
@@ -9,35 +10,24 @@ import net.minecraft.client.gui.components.toasts.ToastComponent;
 import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.NotNull;
 
-public record QuestCompletedToast(Quest quest) implements Toast {
-    private static final long DISPLAY_TIME = 5000L;
+import java.util.List;
+
+public class QuestCompletedToast extends WrappingHintToast implements Toast {
     private static final Component TITLE_TEXT = Component.translatable("quest.heracles.toast");
+    private static final Component KEY_HINT = Component.translatable("quest.heracles.toast.desc", Component.keybind("key.heracles.open_quests"));
+    private final QuestIcon<?> icon;
+
+    public QuestCompletedToast(Quest quest) {
+        super(TITLE_TEXT, List.of(quest.display().title()), List.of(KEY_HINT),5000L);
+        this.icon = quest.display().icon();
+    }
 
     @Override
     @NotNull
     public Toast.Visibility render(GuiGraphics graphics, ToastComponent toastComponent, long timeSinceLastVisible) {
-        graphics.blit(TEXTURE, 0, 0, 0, 0, width(), height());
-        graphics.drawString(
-            toastComponent.getMinecraft().font,
-            TITLE_TEXT, 32, 7, 0xFF800080,
-            false
-        );
-
-        double time = DISPLAY_TIME * toastComponent.getNotificationDisplayTimeMultiplier();
-
-        Component text = timeSinceLastVisible >= (time / 2) ?
-            Component.translatable("quest.heracles.toast.desc", Component.keybind("key.heracles.open_quests")) :
-            quest.display().title();
-
-        graphics.drawString(
-            toastComponent.getMinecraft().font,
-            text, 32, 18, 0xFFFFFFFF,
-            false
-        );
-
-        quest.display().icon().render(graphics, new ScissorBoxStack(), 8, 8, height() / 2, height() / 2);
-
-        return timeSinceLastVisible >= DISPLAY_TIME * toastComponent.getNotificationDisplayTimeMultiplier() ? Toast.Visibility.HIDE : Toast.Visibility.SHOW;
+        Toast.Visibility visible = super.render(graphics, toastComponent, timeSinceLastVisible);
+        icon.render(graphics, new ScissorBoxStack(), 8, height() / 2 - 8, 16, 16);
+        return visible;
     }
 
     public static void add(ToastComponent toastComponent, String quest) {

--- a/common/src/main/java/earth/terrarium/heracles/client/toasts/QuestUnlockedToast.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/toasts/QuestUnlockedToast.java
@@ -2,6 +2,7 @@ package earth.terrarium.heracles.client.toasts;
 
 import com.teamresourceful.resourcefullib.client.scissor.ScissorBoxStack;
 import earth.terrarium.heracles.api.quests.Quest;
+import earth.terrarium.heracles.api.quests.QuestIcon;
 import earth.terrarium.heracles.client.handlers.ClientQuests;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.toasts.Toast;
@@ -9,35 +10,24 @@ import net.minecraft.client.gui.components.toasts.ToastComponent;
 import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.NotNull;
 
-public record QuestUnlockedToast(Quest quest) implements Toast {
-    private static final long DISPLAY_TIME = 5000L;
+import java.util.List;
+
+public final class QuestUnlockedToast extends WrappingHintToast implements Toast {
     private static final Component TITLE_TEXT = Component.translatable("quest_unlocked.heracles.toast");
+    private static final Component KEY_HINT = Component.translatable("quest.heracles.toast.desc", Component.keybind("key.heracles.open_quests"));
+    private final QuestIcon<?> icon;
+
+    public QuestUnlockedToast(Quest quest) {
+        super(TITLE_TEXT, List.of(quest.display().title()), List.of(KEY_HINT), 5000L);
+        this.icon = quest.display().icon();
+    }
 
     @Override
     @NotNull
     public Toast.Visibility render(GuiGraphics graphics, ToastComponent toastComponent, long timeSinceLastVisible) {
-        graphics.blit(TEXTURE, 0, 0, 0, 0, width(), height());
-        graphics.drawString(
-            toastComponent.getMinecraft().font,
-            TITLE_TEXT, 32, 7, 0xFF800080,
-            false
-        );
-
-        double time = DISPLAY_TIME * toastComponent.getNotificationDisplayTimeMultiplier();
-
-        Component text = timeSinceLastVisible >= (time / 2) ?
-            Component.translatable("quest.heracles.toast.desc", Component.keybind("key.heracles.open_quests")) :
-            quest.display().title();
-
-        graphics.drawString(
-            toastComponent.getMinecraft().font,
-            text, 32, 18, 0xFFFFFFFF,
-            false
-        );
-
-        quest.display().icon().render(graphics, new ScissorBoxStack(), 8, 8, height() / 2, height() / 2);
-
-        return timeSinceLastVisible >= DISPLAY_TIME * toastComponent.getNotificationDisplayTimeMultiplier() ? Visibility.HIDE : Visibility.SHOW;
+        Toast.Visibility visible = super.render(graphics, toastComponent, timeSinceLastVisible);
+        icon.render(graphics, new ScissorBoxStack(), 8, height() / 2 - 8, 16, 16);
+        return visible;
     }
 
     public static void add(ToastComponent toastComponent, String quest) {

--- a/common/src/main/java/earth/terrarium/heracles/client/toasts/WrappingHintToast.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/toasts/WrappingHintToast.java
@@ -15,27 +15,23 @@ public class WrappingHintToast implements Toast {
     List<FormattedCharSequence> lines;
     List<FormattedCharSequence> hints;
     private final long duration;
+    private final int height;
 
     public WrappingHintToast(Component title, List<Component> lines, List<Component> hints, long duration) {
         this.title = title;
         this.lines = wrap(lines);
         this.hints = wrap(hints);
         this.duration = duration;
+        this.height = 32 + Math.max(0, Math.max(this.lines.size(), this.hints.size()) - 1) * 11;
     }
 
     @Override
     public Visibility render(GuiGraphics graphics, ToastComponent toastComponent, long timeSinceLastVisible) {
-        int lineHeight = Math.max(lines.size(), hints.size());
-
-        graphics.blit(TEXTURE, 0, 0, 0, 0, width(), 16);
-        for (int i = 0; i < lineHeight - 1; i++) {
-            graphics.blit(TEXTURE, 0, 16 + 11 * i, 0, 8, width(), 11);
-        }
-        graphics.blit(TEXTURE, 0, 16 + 11 * (lineHeight - 1), 0, 16, width(), 16);
+        graphics.blitNineSliced(TEXTURE, 0, 0, width(), height(), 4, 160, 32, 0, 0);
 
         graphics.drawString(
             toastComponent.getMinecraft().font,
-            title, 32, 7, 0xFF800080,
+            title, 32, 7, 0xFFAC43CC,
             false
         );
 
@@ -58,6 +54,6 @@ public class WrappingHintToast implements Toast {
 
     @Override
     public int height() {
-        return 32 + Math.max(0, lines.size() - 1) * 11;
+        return height;
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/client/toasts/WrappingHintToast.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/toasts/WrappingHintToast.java
@@ -31,7 +31,7 @@ public class WrappingHintToast implements Toast {
 
         graphics.drawString(
             toastComponent.getMinecraft().font,
-            title, 32, 7, 0xFFAC43CC,
+            title, 32, 7, 0xFFB52CC8,
             false
         );
 

--- a/common/src/main/java/earth/terrarium/heracles/client/toasts/WrappingHintToast.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/toasts/WrappingHintToast.java
@@ -1,0 +1,63 @@
+package earth.terrarium.heracles.client.toasts;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.toasts.Toast;
+import net.minecraft.client.gui.components.toasts.ToastComponent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.FormattedCharSequence;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WrappingHintToast implements Toast {
+    Component title;
+    List<FormattedCharSequence> lines;
+    List<FormattedCharSequence> hints;
+    private final long duration;
+
+    public WrappingHintToast(Component title, List<Component> lines, List<Component> hints, long duration) {
+        this.title = title;
+        this.lines = wrap(lines);
+        this.hints = wrap(hints);
+        this.duration = duration;
+    }
+
+    @Override
+    public Visibility render(GuiGraphics graphics, ToastComponent toastComponent, long timeSinceLastVisible) {
+        int lineHeight = Math.max(lines.size(), hints.size());
+
+        graphics.blit(TEXTURE, 0, 0, 0, 0, width(), 16);
+        for (int i = 0; i < lineHeight - 1; i++) {
+            graphics.blit(TEXTURE, 0, 16 + 11 * i, 0, 8, width(), 11);
+        }
+        graphics.blit(TEXTURE, 0, 16 + 11 * (lineHeight - 1), 0, 16, width(), 16);
+
+        graphics.drawString(
+            toastComponent.getMinecraft().font,
+            title, 32, 7, 0xFF800080,
+            false
+        );
+
+        double time = duration * toastComponent.getNotificationDisplayTimeMultiplier();
+
+        List<FormattedCharSequence> description = timeSinceLastVisible >= (time / 2) && !hints.isEmpty() ? hints : lines;
+
+        for (int i = 0; i < description.size(); i++) {
+            graphics.drawString(toastComponent.getMinecraft().font, description.get(i), 32, 18 + i * 11, 0xFFFFFF, false);
+        }
+
+        return timeSinceLastVisible >= time ? Toast.Visibility.HIDE : Toast.Visibility.SHOW;
+    }
+
+    private List<FormattedCharSequence> wrap(List<Component> messages) {
+        List<FormattedCharSequence> list = new ArrayList<>();
+        messages.forEach(text -> list.addAll(Minecraft.getInstance().font.split(text, width() - 40)));
+        return list;
+    }
+
+    @Override
+    public int height() {
+        return 32 + Math.max(0, lines.size() - 1) * 11;
+    }
+}


### PR DESCRIPTION
Adds a nice common component capable of wrapping text, showing hints half way through toast duration, and so on. 

Used for quest complete and quest update right now.

![image](https://github.com/terrarium-earth/Heracles/assets/55819817/be73fcde-ce49-4ad5-b6ce-f6bae7f88a06)
![image](https://github.com/terrarium-earth/Heracles/assets/55819817/31dd86ec-970f-4bd0-b720-6b4637cb3486)
![javaw_obuQLkrLhj](https://github.com/terrarium-earth/Heracles/assets/55819817/6dae5288-5618-4f0a-a817-4b4a13a606ae)
![firefox_88ZhFIn4Q7](https://github.com/terrarium-earth/Heracles/assets/55819817/fb237e6e-87ce-4ec7-9cda-b309ba214977)
