### PR TITLE
Lock checkbox buttons when a quest is locked

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/QuestTaskWidgetFactory.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/QuestTaskWidgetFactory.java
@@ -3,14 +3,15 @@ package earth.terrarium.heracles.api.tasks.client;
 import earth.terrarium.heracles.api.client.DisplayWidget;
 import earth.terrarium.heracles.api.tasks.QuestTask;
 import earth.terrarium.heracles.common.handlers.progress.TaskProgress;
+import earth.terrarium.heracles.common.utils.ModUtils;
 import net.minecraft.nbt.Tag;
 
 public interface QuestTaskWidgetFactory<I, S extends Tag, T extends QuestTask<I, S, T>> {
 
-    DisplayWidget create(String quest, T task, TaskProgress<S> progress);
+    DisplayWidget create(String quest, T task, TaskProgress<S> progress, ModUtils.QuestStatus status);
 
-    default DisplayWidget createAndCast(String quest, QuestTask<?, S, ?> task, TaskProgress<S> progress) {
-        return create(quest, this.cast(task), progress);
+    default DisplayWidget createAndCast(String quest, QuestTask<?, S, ?> task, TaskProgress<S> progress, ModUtils.QuestStatus status) {
+        return create(quest, this.cast(task), progress, status);
     }
 
     @SuppressWarnings("unchecked")

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/QuestTaskWidgets.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/QuestTaskWidgets.java
@@ -6,6 +6,7 @@ import earth.terrarium.heracles.api.tasks.QuestTaskType;
 import earth.terrarium.heracles.api.tasks.client.defaults.*;
 import earth.terrarium.heracles.api.tasks.defaults.*;
 import earth.terrarium.heracles.common.handlers.progress.TaskProgress;
+import earth.terrarium.heracles.common.utils.ModUtils;
 import net.minecraft.Optionull;
 import net.minecraft.nbt.Tag;
 import org.jetbrains.annotations.Nullable;
@@ -17,7 +18,11 @@ public final class QuestTaskWidgets {
 
     private static final Map<QuestTaskType<?>, QuestTaskWidgetFactory<?, ?, ?>> FACTORIES = new IdentityHashMap<>();
 
-    public static <I, S extends Tag, T extends QuestTask<I, S, T>> void register(QuestTaskType<T> type, QuestTaskWidgetSimpleFactory<I, S, T> factory) {
+    public static <I, S extends Tag, T extends QuestTask<I, S, T>> void registerSimple(QuestTaskType<T> type, QuestTaskWidgetSimpleFactory<I, S, T> factory) {
+        FACTORIES.put(type, factory);
+    }
+
+    public static <I, S extends Tag, T extends QuestTask<I, S, T>> void register(QuestTaskType<T> type, QuestTaskWidgetBasicFactory<I, S, T> factory) {
         FACTORIES.put(type, factory);
     }
 
@@ -34,35 +39,44 @@ public final class QuestTaskWidgets {
     }
 
     @Nullable
-    public static <T extends Tag> DisplayWidget create(String quest, QuestTask<?, T, ?> task, TaskProgress<T> progress) {
-        return Optionull.map(getFactory(task.type()), factory -> factory.createAndCast(quest, task, progress));
+    public static <T extends Tag> DisplayWidget create(String quest, QuestTask<?, T, ?> task, TaskProgress<T> progress, ModUtils.QuestStatus status) {
+        return Optionull.map(getFactory(task.type()), factory -> factory.createAndCast(quest, task, progress, status));
     }
 
     static {
-        register(KillEntityQuestTask.TYPE, KillEntityTaskWidget::new);
+        registerSimple(KillEntityQuestTask.TYPE, KillEntityTaskWidget::new);
         register(GatherItemTask.TYPE, ItemTaskWidget::new);
-        register(AdvancementTask.TYPE, AdvancementTaskWidget::new);
-        register(RecipeTask.TYPE, RecipeTaskWidget::new);
-        register(StructureTask.TYPE, StructureTaskWidget::new);
-        register(BiomeTask.TYPE, BiomeTaskWidget::new);
-        register(BlockInteractTask.TYPE, BlockInteractTaskWidget::new);
-        register(ItemInteractTask.TYPE, ItemInteractTaskWidget::new);
-        register(ChangedDimensionTask.TYPE, DimensionTaskWidget::new);
+        registerSimple(AdvancementTask.TYPE, AdvancementTaskWidget::new);
+        registerSimple(RecipeTask.TYPE, RecipeTaskWidget::new);
+        registerSimple(StructureTask.TYPE, StructureTaskWidget::new);
+        registerSimple(BiomeTask.TYPE, BiomeTaskWidget::new);
+        registerSimple(BlockInteractTask.TYPE, BlockInteractTaskWidget::new);
+        registerSimple(ItemInteractTask.TYPE, ItemInteractTaskWidget::new);
+        registerSimple(ChangedDimensionTask.TYPE, DimensionTaskWidget::new);
         register(CompositeTask.TYPE, CompositeTaskWidget::new);
         register(CheckTask.TYPE, CheckTaskWidget::new);
-        register(DummyTask.TYPE, DummyTaskWidget::new);
-        register(EntityInteractTask.TYPE, EntityInteractTaskWidget::new);
+        registerSimple(DummyTask.TYPE, DummyTaskWidget::new);
+        registerSimple(EntityInteractTask.TYPE, EntityInteractTaskWidget::new);
         register(XpTask.TYPE, XpTaskWidget::new);
-        register(LocationTask.TYPE, LocationTaskWidget::new);
-        register(StatTask.TYPE, StatTaskWidget::new);
+        registerSimple(LocationTask.TYPE, LocationTaskWidget::new);
+        registerSimple(StatTask.TYPE, StatTaskWidget::new);
     }
 
     public interface QuestTaskWidgetSimpleFactory<I, S extends Tag, T extends QuestTask<I, S, T>> extends QuestTaskWidgetFactory<I, S, T> {
         DisplayWidget create(T task, TaskProgress<S> progress);
 
         @Override
-        default DisplayWidget create(String quest, T task, TaskProgress<S> progress) {
+        default DisplayWidget create(String quest, T task, TaskProgress<S> progress, ModUtils.QuestStatus status) {
             return create(task, progress);
+        }
+    }
+
+    public interface QuestTaskWidgetBasicFactory<I, S extends Tag, T extends QuestTask<I, S, T>> extends QuestTaskWidgetFactory<I, S, T> {
+        DisplayWidget create(String quest, T task, TaskProgress<S> progress);
+
+        @Override
+        default DisplayWidget create(String quest, T task, TaskProgress<S> progress, ModUtils.QuestStatus status) {
+            return create(quest, task, progress);
         }
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/CheckTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/CheckTaskWidget.java
@@ -13,6 +13,7 @@ import earth.terrarium.heracles.common.constants.ConstantComponents;
 import earth.terrarium.heracles.common.handlers.progress.TaskProgress;
 import earth.terrarium.heracles.common.network.NetworkHandler;
 import earth.terrarium.heracles.common.network.packets.tasks.CheckTaskPacket;
+import earth.terrarium.heracles.common.utils.ModUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
@@ -21,7 +22,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 
 public record CheckTaskWidget(
-    String questId, CheckTask task, TaskProgress<ByteTag> progress
+    String questId, CheckTask task, TaskProgress<ByteTag> progress, ModUtils.QuestStatus status
 ) implements DisplayWidget {
 
     private static final ResourceLocation BUTTON_TEXTURE = new ResourceLocation("textures/gui/widgets.png");
@@ -51,22 +52,26 @@ public record CheckTaskWidget(
 
         int buttonY = y + 11;
         boolean buttonHovered = mouseX > x + width - 30 && mouseX < x + width - 10 && mouseY > buttonY && mouseY < buttonY + 20;
-        int v = progress == null || progress.isComplete() ? 46 : buttonHovered ? 86 : 66;
+        int v = !isCompletable() ? 46 : buttonHovered ? 86 : 66;
         graphics.blitNineSliced(BUTTON_TEXTURE, x + width - 30, buttonY, 20, 20, 3, 3, 3, 3, 200, 20, 0, v);
 
         graphics.blit(CHECK_TEXTURE, x + width - 30 + 2, buttonY + 2, 0, 0, 16, 16, 16, 16);
 
         if (buttonHovered) {
-            CursorUtils.setCursor(true, progress != null && !progress.isComplete() ? CursorScreen.Cursor.POINTER : CursorScreen.Cursor.DISABLED);
-            ScreenUtils.setTooltip(ConstantComponents.Tasks.CHECK);
+            CursorUtils.setCursor(true, isCompletable() ? CursorScreen.Cursor.POINTER : CursorScreen.Cursor.DISABLED);
+            if (isCompletable()) ScreenUtils.setTooltip(ConstantComponents.Tasks.CHECK);
         }
+    }
+
+    private boolean isCompletable() {
+        return status != ModUtils.QuestStatus.LOCKED && progress != null && !progress.isComplete();
     }
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int mouseButton, int width) {
         int buttonY = 11;
         boolean buttonHovered = mouseX > width - 30 && mouseX < width - 10 && mouseY > buttonY && mouseY < buttonY + 20;
-        if (buttonHovered && progress != null && !progress.isComplete()) {
+        if (buttonHovered && isCompletable()) {
             this.progress.setComplete(true);
             NetworkHandler.CHANNEL.sendToServer(new CheckTaskPacket(this.questId, this.task.id()));
             return true;

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/CompositeTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/CompositeTaskWidget.java
@@ -27,7 +27,7 @@ public final class CompositeTaskWidget implements DisplayWidget {
 
     private boolean isOpened = false;
 
-    public CompositeTaskWidget(String quest, CompositeTask task, TaskProgress<CollectionTag<Tag>> progress) {
+    public CompositeTaskWidget(String quest, CompositeTask task, TaskProgress<CollectionTag<Tag>> progress, ModUtils.QuestStatus status) {
         this.task = task;
         this.progress = progress;
         this.widgets = new ArrayList<>();
@@ -35,7 +35,7 @@ public final class CompositeTaskWidget implements DisplayWidget {
         for (QuestTask<?, ?, ?> value : task.tasks().values()) {
             TaskProgress<?> valueProgress = new TaskProgress<>(progress.progress().get(i), false);
             valueProgress.updateComplete(ModUtils.cast(value));
-            this.widgets.add(QuestTaskWidgets.create(quest, ModUtils.cast(value), valueProgress));
+            this.widgets.add(QuestTaskWidgets.create(quest, ModUtils.cast(value), valueProgress, status));
             i++;
         }
     }

--- a/common/src/main/java/earth/terrarium/heracles/client/handlers/ClientQuests.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/handlers/ClientQuests.java
@@ -2,15 +2,18 @@ package earth.terrarium.heracles.client.handlers;
 
 import earth.terrarium.heracles.api.quests.Quest;
 import earth.terrarium.heracles.common.handlers.progress.QuestProgress;
+import earth.terrarium.heracles.common.menus.quests.QuestsContent;
 import earth.terrarium.heracles.common.network.NetworkHandler;
 import earth.terrarium.heracles.common.network.packets.quests.ServerboundUpdateQuestPacket;
 import earth.terrarium.heracles.common.network.packets.quests.data.NetworkQuestData;
+import earth.terrarium.heracles.common.utils.ModUtils;
 
 import java.util.*;
 import java.util.function.Function;
 
 public class ClientQuests {
     private static final Map<String, QuestEntry> ENTRIES = new HashMap<>();
+    private static final Map<String, ModUtils.QuestStatus> STATUS = new HashMap<>();
     private static final Map<String, List<QuestEntry>> BY_GROUPS = new HashMap<>();
     private static final List<String> GROUPS = new ArrayList<>();
 
@@ -26,8 +29,8 @@ public class ClientQuests {
 
     public static void sync(Map<String, Quest> quests, List<String> groups) {
         ENTRIES.clear();
-        GROUPS.clear();
         BY_GROUPS.clear();
+        GROUPS.clear();
 
         for (Map.Entry<String, Quest> entry : quests.entrySet()) {
             addEntry(entry.getKey(), entry.getValue(), quests);
@@ -123,6 +126,10 @@ public class ClientQuests {
         return PROGRESS.get(id);
     }
 
+    public static Optional<ModUtils.QuestStatus> getStatus(String id) {
+        return Optional.ofNullable(STATUS.get(id));
+    }
+
     public static List<QuestEntry> byGroup(String group) {
         return BY_GROUPS.getOrDefault(group, List.of());
     }
@@ -136,6 +143,10 @@ public class ClientQuests {
         NetworkQuestData data = builder.build();
         data.update(entry.value());
         NetworkHandler.CHANNEL.sendToServer(new ServerboundUpdateQuestPacket(entry.key(), data));
+    }
+
+    public static void syncGroup(QuestsContent content) {
+        STATUS.putAll(content.quests());
     }
 
     public record QuestEntry(List<QuestEntry> dependencies, String key, Quest value, List<QuestEntry> children) {

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/tasks/TaskListWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/tasks/TaskListWidget.java
@@ -82,7 +82,7 @@ public class TaskListWidget extends AbstractContainerEventHandler implements Ren
         List<MutablePair<QuestTask<?, ?, ?>, DisplayWidget>> completed = new ArrayList<>();
         for (var task : tasks) {
             TaskProgress<?> taskProgress = this.progress.getTask(task);
-            DisplayWidget widget = QuestTaskWidgets.create(this.questId, ModUtils.cast(task), taskProgress);
+            DisplayWidget widget = QuestTaskWidgets.create(this.questId, ModUtils.cast(task), taskProgress, this.quests.get(questId));
             if (widget != null) {
                 if (taskProgress.isComplete()) {
                     completed.add(new MutablePair<>(task, widget));
@@ -194,7 +194,7 @@ public class TaskListWidget extends AbstractContainerEventHandler implements Ren
     public void updateTask(QuestTask<?, ?, ?> task) {
         for (var pair : this.widgets) {
             if (pair.left != null && pair.left.id().equals(task.id())) {
-                var widget = QuestTaskWidgets.create(this.questId, ModUtils.cast(task), this.progress.getTask(task));
+                var widget = QuestTaskWidgets.create(this.questId, ModUtils.cast(task), this.progress.getTask(task), this.quests.get(questId));
                 if (widget != null) {
                     pair.left = task;
                     pair.right = widget;

--- a/common/src/main/java/earth/terrarium/heracles/client/tags/WidgetTagElement.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/tags/WidgetTagElement.java
@@ -23,7 +23,8 @@ public record WidgetTagElement(DisplayWidget widget) implements TagElement {
         var task = quest.tasks().get(parameters.get("task"));
         if (task == null) return new WidgetTagElement(null);
         QuestProgress progress = ClientQuests.getProgress(questId);
-        return new WidgetTagElement(QuestTaskWidgets.create(questId, ModUtils.cast(task), progress.getTask(task)));
+        ModUtils.QuestStatus status = ClientQuests.getStatus(questId).orElse(ModUtils.QuestStatus.LOCKED);
+        return new WidgetTagElement(QuestTaskWidgets.create(questId, ModUtils.cast(task), progress.getTask(task), status));
     }
 
     public static WidgetTagElement ofReward(Map<String, String> parameters) {

--- a/common/src/main/java/earth/terrarium/heracles/common/network/packets/screens/OpenQuestsScreenPacket.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/network/packets/screens/OpenQuestsScreenPacket.java
@@ -5,6 +5,7 @@ import com.teamresourceful.resourcefullib.common.networking.base.PacketContext;
 import com.teamresourceful.resourcefullib.common.networking.base.PacketHandler;
 import earth.terrarium.heracles.Heracles;
 import earth.terrarium.heracles.client.ModScreens;
+import earth.terrarium.heracles.client.handlers.ClientQuests;
 import earth.terrarium.heracles.common.handlers.quests.QuestHandler;
 import earth.terrarium.heracles.common.menus.quests.QuestsContent;
 import net.minecraft.network.FriendlyByteBuf;
@@ -49,6 +50,7 @@ public record OpenQuestsScreenPacket(boolean editing, QuestsContent content) imp
                     player.sendSystemMessage(Component.literal("Manually fix and reload the quests by running /reload"));
                     return;
                 }
+                ClientQuests.syncGroup(message.content);
                 if (message.editing) {
                     ModScreens.openEditQuestsScreen(message.content);
                 } else {


### PR DESCRIPTION
Providing quest status to task widgets was annoying but thankfully not unreasonable.

https://github.com/terrarium-earth/Heracles/assets/55819817/f9b448a5-7886-4932-bd7c-4d6e998437bb

