### PR TITLE
Fix dependency line coords

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
@@ -223,10 +223,10 @@ public class QuestsWidget extends BaseWidget {
                     if (lines.contains(new Pair<>(position, childPosition))) continue;
                     lines.add(new Pair<>(position, childPosition));
 
-                    float px = position.x() + 10.5f;
-                    float py = position.y() + 9.5f;
-                    float cx = childPosition.x() + 10.5f;
-                    float cy = childPosition.y() + 9.5f;
+                    float px = position.x() + 10f;
+                    float py = position.y() + 10f;
+                    float cx = childPosition.x() + 10f;
+                    float cy = childPosition.y() + 10f;
 
                     float length = Mth.sqrt(Mth.square(cx - px) + Mth.square(cy - py));
 

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
@@ -223,10 +223,10 @@ public class QuestsWidget extends BaseWidget {
                     if (lines.contains(new Pair<>(position, childPosition))) continue;
                     lines.add(new Pair<>(position, childPosition));
 
-                    float px = position.x() + 9f;
-                    float py = position.y() + 9f;
-                    float cx = childPosition.x() + 9f;
-                    float cy = childPosition.y() + 9f;
+                    float px = position.x() + 10.5f;
+                    float py = position.y() + 9.5f;
+                    float cx = childPosition.x() + 10.5f;
+                    float cy = childPosition.y() + 9.5f;
 
                     float length = Mth.sqrt(Mth.square(cx - px) + Mth.square(cy - py));
 


### PR DESCRIPTION
Dependency lines were not actually aligned with the centers of quest icons. Default arrow.png is 3x5, and quest icons are 24x24... so offset to center is ~~+10.5f, +9.5f.~~ [Edit: actual correct values are 10, 10; see comment below.]

Before:
![image](https://github.com/terrarium-earth/Heracles/assets/6677700/84c5ed93-ef0c-4896-be9d-d9b544a3ba70)

After:
![image](https://github.com/terrarium-earth/Heracles/assets/6677700/4af2d592-c133-4b2b-9e2b-76188a788bff)
