### PR TITLE
Add `/heracles reset {quest}` command to reset quest state.

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/CompositeTaskWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/defaults/CompositeTaskWidget.java
@@ -18,6 +18,7 @@ import net.minecraft.network.chat.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public final class CompositeTaskWidget implements DisplayWidget {
 
@@ -32,8 +33,9 @@ public final class CompositeTaskWidget implements DisplayWidget {
         this.progress = progress;
         this.widgets = new ArrayList<>();
         int i = 0;
-        for (QuestTask<?, ?, ?> value : task.tasks().values()) {
-            TaskProgress<?> valueProgress = new TaskProgress<>(progress.progress().get(i), false);
+        for (Map.Entry<String, QuestTask<?, ?, ?>> entry : task.tasks().entrySet()) {
+            QuestTask<?, ?, ?> value = entry.getValue();
+            TaskProgress<?> valueProgress = new TaskProgress<>(progress.progress().get(i), task.tasks().get(entry.getKey()).storage()::createDefault, false);
             valueProgress.updateComplete(ModUtils.cast(value));
             this.widgets.add(QuestTaskWidgets.create(quest, ModUtils.cast(value), valueProgress, status));
             i++;

--- a/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/QuestProgress.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/QuestProgress.java
@@ -64,7 +64,7 @@ public class QuestProgress {
         claimed.add(reward);
     }
 
-    public void reset() {
+    void reset() {
         for (TaskProgress<?> taskProgress : tasks.values()) {
             taskProgress.resetProgress();
         }

--- a/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/QuestProgress.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/QuestProgress.java
@@ -27,7 +27,7 @@ public class QuestProgress {
         for (String taskKey : compound.getAllKeys()) {
             if (!quest.tasks().containsKey(taskKey)) continue;
             CompoundTag task = compound.getCompound(taskKey);
-            tasks.put(taskKey, new TaskProgress<>(task.get("progress"), task.getBoolean("complete")));
+            tasks.put(taskKey, new TaskProgress<>(task.get("progress"), quest.tasks().get(taskKey).storage()::createDefault, task.getBoolean("complete")));
         }
     }
 
@@ -62,6 +62,14 @@ public class QuestProgress {
 
     public void claimReward(String reward) {
         claimed.add(reward);
+    }
+
+    public void reset() {
+        for (TaskProgress<?> taskProgress : tasks.values()) {
+            taskProgress.resetProgress();
+        }
+        claimed.clear();
+        complete = false;
     }
 
     public Set<String> claimedRewards() {

--- a/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/QuestProgress.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/QuestProgress.java
@@ -64,9 +64,9 @@ public class QuestProgress {
         claimed.add(reward);
     }
 
-    void reset() {
+    public void reset() {
         for (TaskProgress<?> taskProgress : tasks.values()) {
-            taskProgress.resetProgress();
+            taskProgress.reset();
         }
         claimed.clear();
         complete = false;

--- a/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/QuestsProgress.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/QuestsProgress.java
@@ -64,6 +64,11 @@ public record QuestsProgress(Map<String, QuestProgress> progress, CompletableQue
         syncToTeam(player, editedQuests);
     }
 
+    public void resetQuest(String quest, ServerPlayer player) {
+        progress.get(quest).reset();
+        this.completableQuests.updateCompleteQuests(this, player);
+    }
+
     public <I, T extends QuestTask<I, ?, T>> boolean testAndProgressTask(ServerPlayer player, String id, String task, I input, QuestTaskType<T> taskType) {
         List<String> completableQuests = this.completableQuests.getQuests(this);
         if (!completableQuests.contains(id)) return false;

--- a/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/TaskProgress.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/TaskProgress.java
@@ -30,7 +30,7 @@ public class TaskProgress<S extends Tag> {
         updateComplete(task);
     }
 
-    public void resetProgress() {
+    public void reset() {
         progress = defaultProgress.get();
         setComplete(false);
     }

--- a/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/TaskProgress.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/TaskProgress.java
@@ -4,18 +4,23 @@ import earth.terrarium.heracles.api.tasks.QuestTask;
 import earth.terrarium.heracles.api.tasks.QuestTaskType;
 import net.minecraft.nbt.Tag;
 
+import java.util.function.Supplier;
+
 public class TaskProgress<S extends Tag> {
 
     private S progress;
+    private final Supplier<S> defaultProgress;
     private boolean complete;
 
     public TaskProgress(QuestTask<?, S, ?> task) {
         this.progress = task.storage().createDefault();
+        this.defaultProgress = task.storage()::createDefault;
         this.complete = false;
     }
 
-    public TaskProgress(S progress, boolean complete) {
+    public TaskProgress(S progress, Supplier<S> defaultProgress, boolean complete) {
         this.progress = progress;
+        this.defaultProgress = defaultProgress;
         this.complete = complete;
     }
 
@@ -23,6 +28,11 @@ public class TaskProgress<S extends Tag> {
         if (complete) return;
         progress = task.test(type, progress, input);
         updateComplete(task);
+    }
+
+    public void resetProgress() {
+        progress = defaultProgress.get();
+        setComplete(false);
     }
 
     public boolean isComplete() {
@@ -45,6 +55,6 @@ public class TaskProgress<S extends Tag> {
     }
 
     public TaskProgress<S> copy() {
-        return new TaskProgress<>(progress, complete);
+        return new TaskProgress<>(progress, defaultProgress, complete);
     }
 }

--- a/common/src/main/resources/assets/heracles/lang/en_us.json
+++ b/common/src/main/resources/assets/heracles/lang/en_us.json
@@ -72,5 +72,10 @@
     "setting.heracles.quest.show_dependency_arrow": "Show Dependency Arrow",
 
     "rei.sections.odyssey": "Project Odyssey",
-    "rei.heracles.heracles.tooltip": "Open Quests"
+    "rei.heracles.heracles.tooltip": "Open Quests",
+
+    "commands.heracles.reset.success": "[Heracles] Quest %s reset successfully.",
+    "commands.heracles.pin.success.pinned": "[Heracles] Quest %s pinned.",
+    "commands.heracles.pin.success.unpinned": "[Heracles] Quest %s unpinned.",
+    "commands.heracles.pin.dummy.completed": "[Heracles] Quest %s completed."
 }


### PR DESCRIPTION
Abuses the way that storage works to provide suppliers for the default value for tasks, and provides that to TaskProgress, allowing tasks to be reset.

Adds methods in questprogress and questsprogress to do just that, and a command to call it.

Also adds suggestions to existing commands. The new command uses feedback, and I've added keys for the old ones, but haven't used them as I'm unsure how they're used in datapacking/etc. 

First step to repeatable quests.


https://github.com/terrarium-earth/Heracles/assets/55819817/25a70670-c321-4c56-bba3-76de63c4bbed