### PR TITLE
Add repeatable quest option

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/api/quests/Quest.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/quests/Quest.java
@@ -59,7 +59,7 @@ public record Quest(
             rewards().values().stream().
                 filter(QuestReward::canBeMassClaimed)
                 .filter(reward -> !questProgress.claimedRewards().contains(reward.id()))
-                .peek(reward -> questProgress.claimReward(reward.id()))
+                .peek(reward -> progress.claimReward(id, reward.id(), player))
         );
     }
 
@@ -73,7 +73,7 @@ public record Quest(
         if (rewards.containsKey(rewardId) && !questProgress.claimedRewards().contains(rewardId)) {
             var reward = rewards.get(rewardId);
             if (reward.canBeMassClaimed()) {
-                questProgress.claimReward(rewardId);
+                progress.claimReward(id, rewardId, player);
                 claimRewards(
                     id,
                     player,

--- a/common/src/main/java/earth/terrarium/heracles/api/quests/QuestSettings.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/quests/QuestSettings.java
@@ -12,23 +12,26 @@ public final class QuestSettings {
         Codec.BOOL.fieldOf("individual_progress").orElse(false).forGetter(QuestSettings::individualProgress),
         EnumCodec.of(ModUtils.QuestStatus.class).orElse(ModUtils.QuestStatus.LOCKED).fieldOf("hidden").forGetter(QuestSettings::hiddenUntil),
         Codec.BOOL.fieldOf("unlockNotification").orElse(false).forGetter(QuestSettings::unlockNotification),
-        Codec.BOOL.fieldOf("showDependencyArrow").orElse(true).forGetter(QuestSettings::showDependencyArrow)
+        Codec.BOOL.fieldOf("showDependencyArrow").orElse(true).forGetter(QuestSettings::showDependencyArrow),
+        Codec.BOOL.fieldOf("repeatable").orElse(false).forGetter(QuestSettings::repeatable)
     ).apply(instance, QuestSettings::new));
 
     private boolean individualProgress;
     private ModUtils.QuestStatus hiddenUntil;
     private boolean unlockNotification;
     private boolean showDependencyArrow;
+    private boolean repeatable;
 
-    public QuestSettings(boolean individualProgress, ModUtils.QuestStatus hiddenUntil, boolean unlockNotification, boolean showDependencyArrow) {
+    public QuestSettings(boolean individualProgress, ModUtils.QuestStatus hiddenUntil, boolean unlockNotification, boolean showDependencyArrow, boolean repeatable) {
         this.individualProgress = individualProgress;
         this.hiddenUntil = hiddenUntil;
         this.unlockNotification = unlockNotification;
         this.showDependencyArrow = showDependencyArrow;
+        this.repeatable = repeatable;
     }
 
     public static QuestSettings createDefault() {
-        return new QuestSettings(false, ModUtils.QuestStatus.LOCKED, false, true);
+        return new QuestSettings(false, ModUtils.QuestStatus.LOCKED, false, true, false);
     }
 
     public boolean individualProgress() {
@@ -47,6 +50,10 @@ public final class QuestSettings {
         return showDependencyArrow;
     }
 
+    public Boolean repeatable() {
+        return repeatable;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) return true;
@@ -56,12 +63,13 @@ public final class QuestSettings {
             this.individualProgress == that.individualProgress &&
             this.hiddenUntil == that.hiddenUntil &&
             this.unlockNotification == that.unlockNotification &&
-            this.showDependencyArrow == that.showDependencyArrow;
+            this.showDependencyArrow == that.showDependencyArrow &&
+            this.repeatable == that.repeatable;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(individualProgress, hiddenUntil, unlockNotification, showDependencyArrow);
+        return Objects.hash(individualProgress, hiddenUntil, unlockNotification, showDependencyArrow, repeatable);
     }
 
     public void update(QuestSettings newSettings) {
@@ -69,6 +77,7 @@ public final class QuestSettings {
         this.hiddenUntil = newSettings.hiddenUntil;
         this.unlockNotification = newSettings.unlockNotification;
         this.showDependencyArrow = newSettings.showDependencyArrow;
+        this.repeatable = newSettings.repeatable;
     }
 
     public void setIndividualProgress(boolean individualProgress) {
@@ -85,6 +94,10 @@ public final class QuestSettings {
 
     public void setShowDependencyArrow(boolean showDependencyArrow) {
         this.showDependencyArrow = showDependencyArrow;
+    }
+
+    public void setRepeatable(boolean repeatable) {
+        this.repeatable = repeatable;
     }
 
 }

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/BaseQuestScreen.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/BaseQuestScreen.java
@@ -48,9 +48,7 @@ public abstract class BaseQuestScreen extends AbstractQuestScreen<QuestContent> 
 
     public void updateProgress(@Nullable QuestProgress newProgress) {
         if (newProgress != null) {
-            newProgress.claimedRewards().forEach(this.content.progress()::claimReward);
-            newProgress.tasks().forEach((id, taskProgress) -> this.content.progress().tasks().put(id, taskProgress));
-            this.content.progress().checkComplete();
+            this.content.progress().copyFrom(newProgress);
         }
         if (this.claimRewards != null) {
             this.claimRewards.active = this.content.progress().isComplete() && this.content.progress().claimedRewards().size() < this.quest().rewards().size();

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestSettingsInitalizer.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestSettingsInitalizer.java
@@ -18,6 +18,7 @@ public class QuestSettingsInitalizer implements SettingInitializer<QuestSettings
         settings.put("hidden", new EnumSetting<>(ModUtils.QuestStatus.class, ModUtils.QuestStatus.LOCKED), object != null ? object.hiddenUntil() : ModUtils.QuestStatus.LOCKED);
         settings.put("unlock_notification", BooleanSetting.FALSE, object != null && object.unlockNotification());
         settings.put("show_dependency_arrow", BooleanSetting.TRUE, object != null && object.showDependencyArrow());
+        settings.put("repeatable", BooleanSetting.FALSE, object != null && object.repeatable());
         return settings;
     }
 
@@ -27,7 +28,8 @@ public class QuestSettingsInitalizer implements SettingInitializer<QuestSettings
             data.get("individual_progress", BooleanSetting.FALSE).orElse(object != null && object.individualProgress()),
             data.get("hidden", new EnumSetting<>(ModUtils.QuestStatus.class, ModUtils.QuestStatus.LOCKED)).orElse(object != null ? object.hiddenUntil() : ModUtils.QuestStatus.LOCKED),
             data.get("unlock_notification", BooleanSetting.FALSE).orElse(object != null && object.unlockNotification()),
-            data.get("show_dependency_arrow", BooleanSetting.TRUE).orElse(object != null && object.showDependencyArrow())
+            data.get("show_dependency_arrow", BooleanSetting.TRUE).orElse(object != null && object.showDependencyArrow()),
+            data.get("repeatable", BooleanSetting.FALSE).orElse(object != null && object.repeatable())
         );
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quests/SelectQuestWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quests/SelectQuestWidget.java
@@ -148,7 +148,8 @@ public class SelectQuestWidget extends BaseWidget {
                                 .individualProgress(questSettings.individualProgress())
                                 .hiddenUntil(questSettings.hiddenUntil())
                                 .unlockNotification(questSettings.unlockNotification())
-                                .showDependencyArrow(questSettings.showDependencyArrow());
+                                .showDependencyArrow(questSettings.showDependencyArrow())
+                                .repeatable(questSettings.repeatable());
                         })
                     );
                     edit.setTitle(Component.literal("Edit Quest Settings"));

--- a/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/QuestProgress.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/QuestProgress.java
@@ -89,6 +89,15 @@ public class QuestProgress {
         return this.tasks;
     }
 
+    public void copyFrom(QuestProgress progress) {
+        claimed.clear();
+        claimed.addAll(progress.claimed);
+        tasks.clear();
+        tasks.putAll(progress.tasks);
+        complete = progress.complete;
+        checkComplete();
+    }
+
     public CompoundTag save() {
         CompoundTag tag = new CompoundTag();
         tag.putBoolean("complete", complete);

--- a/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/QuestsProgress.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/QuestsProgress.java
@@ -69,6 +69,15 @@ public record QuestsProgress(Map<String, QuestProgress> progress, CompletableQue
         this.completableQuests.updateCompleteQuests(this, player);
     }
 
+
+    public void claimReward(String questId, String rewardId, ServerPlayer player) {
+        progress.get(questId).claimReward(rewardId);
+        Quest quest = QuestHandler.get(questId);
+        if (quest.settings().repeatable() && progress.get(questId).claimedRewards().size() == quest.rewards().size()) {
+            resetQuest(questId, player);
+        }
+    }
+
     public <I, T extends QuestTask<I, ?, T>> boolean testAndProgressTask(ServerPlayer player, String id, String task, I input, QuestTaskType<T> taskType) {
         List<String> completableQuests = this.completableQuests.getQuests(this);
         if (!completableQuests.contains(id)) return false;

--- a/common/src/main/java/earth/terrarium/heracles/common/network/packets/quests/data/NetworkQuestData.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/network/packets/quests/data/NetworkQuestData.java
@@ -68,6 +68,7 @@ public record NetworkQuestData(
         private ModUtils.QuestStatus hiddenUntil = null;
         private TriState unlockNotification = TriState.UNDEFINED;
         private TriState showDependencyArrow = TriState.UNDEFINED;
+        private TriState repeatable = TriState.UNDEFINED;
         private Set<String> dependencies;
         private Map<String, QuestTask<?, ?, ?>> tasks;
         private Map<String, QuestReward<?>> rewards;
@@ -132,6 +133,11 @@ public record NetworkQuestData(
             return this;
         }
 
+        public Builder repeatable(boolean repeatable) {
+            this.repeatable = TriState.of(repeatable);
+            return this;
+        }
+
         public Builder dependencies(Set<String> dependencies) {
             this.dependencies = new HashSet<>(dependencies);
             return this;
@@ -165,7 +171,8 @@ public record NetworkQuestData(
                     Optional.ofNullable(individualProgress.isUndefined() ? null : individualProgress.isTrue()),
                     Optional.ofNullable(hiddenUntil),
                     Optional.ofNullable(unlockNotification.isUndefined() ? null : unlockNotification.isTrue()),
-                    Optional.ofNullable(showDependencyArrow.isUndefined() ? null : showDependencyArrow.isTrue())
+                    Optional.ofNullable(showDependencyArrow.isUndefined() ? null : showDependencyArrow.isTrue()),
+                    Optional.ofNullable(repeatable.isUndefined() ? null : repeatable.isTrue())
                 );
             }
 

--- a/common/src/main/java/earth/terrarium/heracles/common/network/packets/quests/data/NetworkQuestSettingsData.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/network/packets/quests/data/NetworkQuestSettingsData.java
@@ -12,7 +12,8 @@ public record NetworkQuestSettingsData(
     Optional<Boolean> individualProgress,
     Optional<ModUtils.QuestStatus> hiddenUntil,
     Optional<Boolean> unlockNotification,
-    Optional<Boolean> showDependencyArrow
+    Optional<Boolean> showDependencyArrow,
+    Optional<Boolean> repeatable
 ) {
 
     public static final ByteCodec<NetworkQuestSettingsData> CODEC = ObjectByteCodec.create(
@@ -20,6 +21,7 @@ public record NetworkQuestSettingsData(
         ByteCodec.ofEnum(ModUtils.QuestStatus.class).optionalFieldOf(NetworkQuestSettingsData::hiddenUntil),
         ByteCodec.BOOLEAN.optionalFieldOf(NetworkQuestSettingsData::unlockNotification),
         ByteCodec.BOOLEAN.optionalFieldOf(NetworkQuestSettingsData::showDependencyArrow),
+        ByteCodec.BOOLEAN.optionalFieldOf(NetworkQuestSettingsData::repeatable),
         NetworkQuestSettingsData::new
     );
 
@@ -29,5 +31,6 @@ public record NetworkQuestSettingsData(
         hiddenUntil.ifPresent(settings::setHiddenUntil);
         unlockNotification.ifPresent(settings::setUnlockNotification);
         showDependencyArrow.ifPresent(settings::setShowDependencyArrow);
+        repeatable.ifPresent(settings::setRepeatable);
     }
 }

--- a/common/src/main/resources/assets/heracles/lang/en_us.json
+++ b/common/src/main/resources/assets/heracles/lang/en_us.json
@@ -74,6 +74,7 @@
     "setting.heracles.quest.hidden": "Hidden Until",
     "setting.heracles.quest.unlock_notification": "Unlock Notification",
     "setting.heracles.quest.show_dependency_arrow": "Show Dependency Arrow",
+    "setting.heracles.quest.repeatable": "Repeatable",
 
     "rei.sections.odyssey": "Project Odyssey",
     "rei.heracles.heracles.tooltip": "Open Quests",


### PR DESCRIPTION
closes #54 

Adds the quest setting for repeatable quests, and implements it by moving reward claim logic slightly to allow the reset functions to be called if all rewards are claimed.

https://github.com/terrarium-earth/Heracles/assets/55819817/8dcc8b99-5048-403b-971d-7f6adf66735b

