### PR TITLE
Fix background modal crash, allow variable height for quest backgrounds in modal

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/client/widgets/modals/icon/background/BackgroundModalItem.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/widgets/modals/icon/background/BackgroundModalItem.java
@@ -17,14 +17,17 @@ import org.joml.Matrix4f;
 public record BackgroundModalItem(ResourceLocation texture) {
 
     public static final int WIDTH = 152;
-    public static final int HEIGHT = 28;
+
+    public int height() {
+        return TexturePlacements.getOrDefault(texture, TexturePlacements.NO_OFFSET_24X).height() + 4;
+    }
 
     public void render(GuiGraphics graphics, ScissorBoxStack ignored, int x, int y, int mouseX, int mouseY, boolean hovering) {
-        graphics.blit(UploadModal.TEXTURE, x, y, 0, 173, WIDTH, HEIGHT, 256, 256);
+        TexturePlacements.Info info = TexturePlacements.getOrDefault(texture, TexturePlacements.NO_OFFSET_24X);
+
+        graphics.blitNineSliced(UploadModal.TEXTURE, x, y, WIDTH, info.height() + 4, 3, 152, 28, 0, 173);
 
         RenderSystem.setShaderTexture(0, texture);
-
-        TexturePlacements.Info info = TexturePlacements.get(texture);
         Matrix4f matrix = graphics.pose().last().pose();
 
         int xStart = (WIDTH - info.width() * 4) / 2;
@@ -38,7 +41,7 @@ public record BackgroundModalItem(ResourceLocation texture) {
         bufferBuilder.vertex(matrix, x + xStart + info.width() * 4, y + 2, 0).uv(1, 0).endVertex();
         BufferUploader.drawWithShader(bufferBuilder.end());
 
-        if (hovering && mouseX >= x && mouseX <= x + WIDTH && mouseY >= y && mouseY <= y + HEIGHT) {
+        if (hovering && mouseX >= x && mouseX <= x + WIDTH && mouseY >= y && mouseY <= y + info.height() + 4) {
             CursorUtils.setCursor(true, CursorScreen.Cursor.POINTER);
             String textureName = texture.getNamespace() + ":" + texture.getPath().substring("textures/gui/quest_backgrounds/".length());
             ScreenUtils.setTooltip(Component.literal(textureName));

--- a/common/src/main/java/earth/terrarium/heracles/client/widgets/modals/icon/background/IconBackgroundModal.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/widgets/modals/icon/background/IconBackgroundModal.java
@@ -22,6 +22,7 @@ public class IconBackgroundModal extends BaseModal {
     private static final int HEIGHT = 173;
 
     private double scrollAmount = 0;
+    private int innerHeight = 0;
 
     private final List<BackgroundModalItem> items = new ArrayList<>();
     private Consumer<ResourceLocation> callback;
@@ -48,14 +49,13 @@ public class IconBackgroundModal extends BaseModal {
 
         int y = this.y + 19;
         int x = this.x + 8;
-        int tempY = y;
-        tempY -= scrollAmount;
+        innerHeight = 0;
 
         try (var scissor = RenderUtils.createScissor(Minecraft.getInstance(), graphics, x, y, 152, 130)) {
             for (BackgroundModalItem item : items) {
                 boolean hovering = mouseY >= y && mouseY <= y + 148;
-                item.render(graphics, scissor.stack(), x, tempY, mouseX, mouseY, hovering);
-                tempY += 28;
+                item.render(graphics, scissor.stack(), x, y - (int) scrollAmount + innerHeight, mouseX, mouseY, hovering);
+                innerHeight += item.height();
             }
         }
     }
@@ -78,14 +78,14 @@ public class IconBackgroundModal extends BaseModal {
 
         for (BackgroundModalItem item : items) {
             if (mouseY >= y && mouseY <= y + 148) {
-                if (mouseX >= x && mouseX <= x + UploadModalItem.WIDTH && mouseY >= tempY && mouseY <= tempY + 28) {
+                if (mouseX >= x && mouseX <= x + UploadModalItem.WIDTH && mouseY >= tempY && mouseY <= tempY + item.height()) {
                     if (callback != null) {
                         callback.accept(item.texture());
                     }
                     return true;
                 }
             }
-            tempY += 28;
+            tempY += item.height();
         }
 
         return true;
@@ -93,7 +93,7 @@ public class IconBackgroundModal extends BaseModal {
 
     @Override
     public boolean mouseScrolled(double mouseX, double mouseY, double scrollAmount) {
-        this.scrollAmount = Mth.clamp(this.scrollAmount - scrollAmount * 10, 0.0D, Math.max(0, (this.items.size() * 28) - 130));
+        this.scrollAmount = Mth.clamp(this.scrollAmount - scrollAmount * 10, 0.0D, Math.max(0, innerHeight - 130));
         return true;
     }
 


### PR DESCRIPTION
Prevents crashing when the background modal is opened due to no defaults being present. Allows larger buttons to be rendered to fit larger textures.

https://github.com/terrarium-earth/Heracles/assets/55819817/a122c5af-70e0-4ecf-9424-47bfafc3e6bb

