### PR TITLE
Arrow render fixes

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
@@ -214,7 +214,7 @@ public class QuestsWidget extends BaseWidget {
             for (ClientQuests.QuestEntry entry : this.entries) {
                 var position = entry.value().display().position(this.group);
 
-                boolean isHovered = isMouseOver(mouseX, mouseY) && mouseX >= x + offset.x() + position.x() && mouseX <= x + offset.x() + position.x() && mouseY >= y + offset.y() + position.y() && mouseY <= y + offset.y() + position.y();
+                boolean isHovered = isMouseOver(mouseX, mouseY) && mouseX >= x + offset.x() + position.x() && mouseX <= x + offset.x() + position.x() + 32 && mouseY >= y + offset.y() + position.y() && mouseY <= y + offset.y() + position.y() + 32;
 
                 RenderSystem.setShaderColor(0.9F, 0.9F, 0.9F, isHovered ? 0.8f : 0.4F);
 

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
@@ -216,7 +216,7 @@ public class QuestsWidget extends BaseWidget {
 
                 boolean isHovered = isMouseOver(mouseX, mouseY) && mouseX >= x + offset.x() + position.x() && mouseX <= x + offset.x() + position.x() && mouseY >= y + offset.y() + position.y() && mouseY <= y + offset.y() + position.y();
 
-                RenderSystem.setShaderColor(0.9F, 0.9F, 0.9F, isHovered ? 0.45f : 0.25F);
+                RenderSystem.setShaderColor(0.9F, 0.9F, 0.9F, isHovered ? 0.8f : 0.4F);
 
                 for (ClientQuests.QuestEntry child : entry.children()) {
                     if (!child.value().display().groups().containsKey(this.group)) continue;

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
@@ -214,7 +214,11 @@ public class QuestsWidget extends BaseWidget {
             for (ClientQuests.QuestEntry entry : this.entries) {
                 var position = entry.value().display().position(this.group);
 
-                boolean isHovered = isMouseOver(mouseX, mouseY) && mouseX >= x + offset.x() + position.x() && mouseX <= x + offset.x() + position.x() + 32 && mouseY >= y + offset.y() + position.y() && mouseY <= y + offset.y() + position.y() + 32;
+                boolean isHovered = isMouseOver(mouseX, mouseY) &&
+                                    mouseX >= x + offset.x() + position.x() &&
+                                    mouseX <= x + offset.x() + position.x() + 32 &&
+                                    mouseY >= y + offset.y() + position.y() &&
+                                    mouseY <= y + offset.y() + position.y() + 32;
 
                 RenderSystem.setShaderColor(0.9F, 0.9F, 0.9F, isHovered ? 0.8f : 0.4F);
 


### PR DESCRIPTION
Comprises three small commits:

1. Improves arrow visibility by raising the alpha values it is drawn with.

2. Fixes the logic of the `isHovered` test by considering the width and height of the quest.
_This was done with a terrible hack:_ **hard-coded width and height**. 

3. Formatting: broke the very long `isHovered` conditional across multiple lines. Followed Google's Java Style Guide: https://google.github.io/styleguide/javaguide.html#s4.5-line-wrapping