### PR TITLE
Face entities on widgets into the light

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/api/client/WidgetUtils.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/client/WidgetUtils.java
@@ -85,7 +85,7 @@ public final class WidgetUtils {
         x += (int) (size / 40f < 1 ? -6 * size / 40f : 5 * size / 40f);
         y += (int) (size / 40f < 1 ? -6 * size / 40f : 8 * size / 35f);
 
-        float rot = 45f;
+        float rot = -45f;
         if (entity instanceof EnderDragon) {
             // Ender dragon is rotated 180 degrees
             rot = 225f;


### PR DESCRIPTION
This rotates entity icons on widgets (tasks, and in theory, rewards) -45 instead of 45.

This faces the entity into the light, instead of into shadow.

For villager professions, the 'face' face of their textures, generall, has key visually distingishing features. Hence, this change improves their legibility, especially as they are rendered small enough to fit the widget.

An alternate fix, probably better but unknown to me how or if is possible, would be to move the light 90 degrees. Would love to learn how if so.

*Addresses issue #142.