### PR TITLE
Better Centering of Hermes' DocumentWidget within Heracles' display

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/QuestScreen.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/QuestScreen.java
@@ -40,7 +40,7 @@ public class QuestScreen extends BaseQuestScreen {
         int contentX = this.overview == null ? (int) ((this.width - contentWidth) / 2f) : (int) (this.width * 0.31f);
         int contentY = 15;
         TagProvider provider = new QuestTagProvider();
-        this.description = new DocumentWidget(contentX, contentY, contentWidth + 6, contentHeight + 6,5.0D, 5.0D, new DefaultTheme(), provider.parse(desc));
+        this.description = new DocumentWidget(contentX, contentY, contentWidth + 12, contentHeight + 6,5.0D, 5.0D, new DefaultTheme(), provider.parse(desc));
     }
 
     @Override


### PR DESCRIPTION
Tested at UI scales 2, 3, and 4.

When there are no tasks or rewards (and hence, no left margin), centering is dead on.

When there is a left margin...
	...and UI scale is 3: centering is spot on.
	...and UI scale is 2 or 4: centering is off by one font "pixel"; a forgivable amount for now.

Undocumented magic numbers are bad and unsatisfying though.
How Hermes' is centering text, <img> tags, and horizontal rules is a factor. (the later were measured down to the pixel in screen shots as a stand-in for Hermes' position and width)

This is the minimal change I could come up with staying within Heracles' code.