### PR TITLE
Treat empty lines as an implicit `<br/>`.

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/MarkdownParser.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/MarkdownParser.java
@@ -68,6 +68,8 @@ public class MarkdownParser {
                 builder.add(parse(List.of(line.substring(2).trim())).stream().reduce("", (a, b) -> a + b));
             } else if (trimedText.trim().startsWith("<")) {
                 builder.add(line);
+            } else if (trimedText.isEmpty()) {
+                builder.add("<br/>");
             } else {
                 String json = Component.Serializer.toJson(parseTextToComponent(line));
                 builder.add("<component>" + xmlEncode(json) + "</component>");


### PR DESCRIPTION
Currently empty descrption lines (in the editor and the json) are simply ignored.
This would save visual noise and keystrokes, with no impact on explicit `<br/>`s.

(and my fingers would be happier, believe me. ^^)