### PR TITLE
fix: save the before progress correctly

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/QuestsProgress.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/handlers/progress/QuestsProgress.java
@@ -36,7 +36,7 @@ public record QuestsProgress(Map<String, QuestProgress> progress, CompletableQue
             for (QuestTask<?, ?, ?> task : quest.tasks().values()) {
                 if (task.isCompatibleWith(taskType)) {
                     TaskProgress<?> progress = questProgress.getTask(task);
-                    Tag before = progress.progress();
+                    Tag before = progress.progress().copy();
                     if (progress.isComplete()) continue;
                     progress.addProgress(taskType, ModUtils.cast(task), input);
                     if (progress.isComplete()) {


### PR DESCRIPTION
fix #81

The same instance will cause the `editedQuests` always ignore the task since they are the same