### PR TITLE
Optimize entry adding logic, use clearer naming

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/client/handlers/ClientQuests.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/handlers/ClientQuests.java
@@ -85,7 +85,7 @@ public class ClientQuests {
 
         QuestEntry entry = new QuestEntry(key, quest, dependencies);
 
-        dependencies.forEach(dependency -> dependency.dependants().add(entry));
+        dependencies.forEach(dependency -> dependency.dependents().add(entry));
 
         ENTRIES.put(key, entry);
         return entry;
@@ -96,9 +96,9 @@ public class ClientQuests {
         BY_GROUPS.values().forEach(list -> list.removeIf(entry -> entry.key().equals(id)));
         if (quest != null) {
             for (QuestEntry dependency : quest.dependencies()) {
-                dependency.dependants().remove(quest);
+                dependency.dependents().remove(quest);
             }
-            for (QuestEntry child : quest.dependants()) {
+            for (QuestEntry child : quest.dependents()) {
                 child.dependencies().remove(quest);
             }
         }
@@ -111,13 +111,13 @@ public class ClientQuests {
             QuestEntry dependent = ENTRIES.get(dependency);
             if (dependent != null) {
                 entry.dependencies().add(dependent);
-                dependent.dependants().removeIf(child -> child.key().equals(id));
-                dependent.dependants().add(entry);
+                dependent.dependents().removeIf(child -> child.key().equals(id));
+                dependent.dependents().add(entry);
             }
         }
         for (QuestEntry value : ENTRIES.values()) {
             if (value.value.dependencies().contains(id)) {
-                entry.dependants().add(value);
+                entry.dependents().add(value);
                 value.dependencies().removeIf(dependency -> dependency.key().equals(id));
                 value.dependencies().add(entry);
             }
@@ -168,7 +168,7 @@ public class ClientQuests {
         STATUS.putAll(content.quests());
     }
 
-    public record QuestEntry(String key, Quest value, List<QuestEntry> dependencies, List<QuestEntry> dependants) {
+    public record QuestEntry(String key, Quest value, List<QuestEntry> dependencies, List<QuestEntry> dependents) {
 
         public QuestEntry(String key, Quest value, List<QuestEntry> dependencies) {
             this(key, value, dependencies, new ArrayList<>());

--- a/common/src/main/java/earth/terrarium/heracles/client/handlers/ClientQuests.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/handlers/ClientQuests.java
@@ -67,21 +67,28 @@ public class ClientQuests {
         Quest quest,
         Map<String, Quest> quests
     ) {
+        QuestEntry existingEntry = ENTRIES.get(key);
+
+        if (existingEntry != null) {
+            return existingEntry;
+        }
+
         List<QuestEntry> dependencies = new ArrayList<>();
+
         for (String dependency : quest.dependencies()) {
             Quest dependent = quests.get(dependency);
+
             if (dependent != null && !dependent.dependencies().contains(key) && !key.equals(dependency)) {
-                QuestEntry dependencyEntry = addEntry(dependency, dependent, quests);
-                if (dependencyEntry != null) {
-                    dependencies.add(dependencyEntry);
-                }
+                dependencies.add(addEntry(dependency, dependent, quests));
             }
         }
 
-        QuestEntry entry = new QuestEntry(dependencies, key, quest, new ArrayList<>());
-        dependencies.forEach(dependency -> dependency.children().add(entry));
+        QuestEntry entry = new QuestEntry(key, quest, dependencies);
 
-        return ENTRIES.computeIfAbsent(key, k -> entry);
+        dependencies.forEach(dependency -> dependency.dependants().add(entry));
+
+        ENTRIES.put(key, entry);
+        return entry;
     }
 
     public static void remove(String id) {
@@ -89,9 +96,9 @@ public class ClientQuests {
         BY_GROUPS.values().forEach(list -> list.removeIf(entry -> entry.key().equals(id)));
         if (quest != null) {
             for (QuestEntry dependency : quest.dependencies()) {
-                dependency.children().remove(quest);
+                dependency.dependants().remove(quest);
             }
-            for (QuestEntry child : quest.children()) {
+            for (QuestEntry child : quest.dependants()) {
                 child.dependencies().remove(quest);
             }
         }
@@ -99,18 +106,18 @@ public class ClientQuests {
 
     public static QuestEntry addQuest(String id, Quest quest) {
         remove(id);
-        QuestEntry entry = new QuestEntry(new ArrayList<>(), id, quest, new ArrayList<>());
+        QuestEntry entry = new QuestEntry(id, quest);
         for (String dependency : quest.dependencies()) {
             QuestEntry dependent = ENTRIES.get(dependency);
             if (dependent != null) {
                 entry.dependencies().add(dependent);
-                dependent.children().removeIf(child -> child.key().equals(id));
-                dependent.children().add(entry);
+                dependent.dependants().removeIf(child -> child.key().equals(id));
+                dependent.dependants().add(entry);
             }
         }
         for (QuestEntry value : ENTRIES.values()) {
             if (value.value.dependencies().contains(id)) {
-                entry.children().add(value);
+                entry.dependants().add(value);
                 value.dependencies().removeIf(dependency -> dependency.key().equals(id));
                 value.dependencies().add(entry);
             }
@@ -161,7 +168,15 @@ public class ClientQuests {
         STATUS.putAll(content.quests());
     }
 
-    public record QuestEntry(List<QuestEntry> dependencies, String key, Quest value, List<QuestEntry> children) {
+    public record QuestEntry(String key, Quest value, List<QuestEntry> dependencies, List<QuestEntry> dependants) {
+
+        public QuestEntry(String key, Quest value, List<QuestEntry> dependencies) {
+            this(key, value, dependencies, new ArrayList<>());
+        }
+
+        public QuestEntry(String key, Quest value) {
+            this(key, value, new ArrayList<>());
+        }
 
         @Override
         public String toString() {

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/rewards/RewardListWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/rewards/RewardListWidget.java
@@ -120,7 +120,7 @@ public class RewardListWidget extends AbstractContainerEventHandler implements R
         }
         ClientQuests.get(id).ifPresent(entry -> {
             List<ClientQuests.QuestEntry> children = new ArrayList<>();
-            for (ClientQuests.QuestEntry child : entry.dependants()) {
+            for (ClientQuests.QuestEntry child : entry.dependents()) {
                 if (!child.value().display().groups().containsKey(group)) {
                     children.add(child);
                 }

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/rewards/RewardListWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/rewards/RewardListWidget.java
@@ -120,7 +120,7 @@ public class RewardListWidget extends AbstractContainerEventHandler implements R
         }
         ClientQuests.get(id).ifPresent(entry -> {
             List<ClientQuests.QuestEntry> children = new ArrayList<>();
-            for (ClientQuests.QuestEntry child : entry.children()) {
+            for (ClientQuests.QuestEntry child : entry.dependants()) {
                 if (!child.value().display().groups().containsKey(group)) {
                     children.add(child);
                 }

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
@@ -238,7 +238,7 @@ public class QuestsWidget extends BaseWidget {
 
                 RenderSystem.setShaderColor(0.9F, 0.9F, 0.9F, isHovered ? 0.8f : 0.4F);
 
-                for (ClientQuests.QuestEntry child : entry.dependants()) {
+                for (ClientQuests.QuestEntry child : entry.dependents()) {
                     if (!child.value().display().groups().containsKey(this.group)) continue;
                     if (!this.visibleQuests.contains(child.key())) continue;
                     if (!child.value().settings().showDependencyArrow()) continue;

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
@@ -238,7 +238,7 @@ public class QuestsWidget extends BaseWidget {
 
                 RenderSystem.setShaderColor(0.9F, 0.9F, 0.9F, isHovered ? 0.8f : 0.4F);
 
-                for (ClientQuests.QuestEntry child : entry.children()) {
+                for (ClientQuests.QuestEntry child : entry.dependants()) {
                     if (!child.value().display().groups().containsKey(this.group)) continue;
                     if (!this.visibleQuests.contains(child.key())) continue;
                     if (!child.value().settings().showDependencyArrow()) continue;

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quests/SelectQuestHandler.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quests/SelectQuestHandler.java
@@ -43,12 +43,12 @@ public class SelectQuestHandler {
             ClientQuests.updateQuest(quest.entry(), value -> {
                 if (Screen.hasShiftDown()) {
                     quest.quest().dependencies().remove(selectedQuest.id());
-                    selectedQuest.entry().dependants().remove(quest.entry());
+                    selectedQuest.entry().dependents().remove(quest.entry());
                     quest.entry().dependencies().remove(quest.entry());
                 } else {
-                    if (!quest.entry().dependants().contains(selectedQuest.entry())) {
+                    if (!quest.entry().dependents().contains(selectedQuest.entry())) {
                         if (quest.quest().dependencies().add(selectedQuest.id())) {
-                            selectedQuest.entry().dependants().add(quest.entry());
+                            selectedQuest.entry().dependents().add(quest.entry());
                             quest.entry().dependencies().add(selectedQuest.entry());
                         }
                     }

--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quests/SelectQuestHandler.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quests/SelectQuestHandler.java
@@ -43,12 +43,12 @@ public class SelectQuestHandler {
             ClientQuests.updateQuest(quest.entry(), value -> {
                 if (Screen.hasShiftDown()) {
                     quest.quest().dependencies().remove(selectedQuest.id());
-                    selectedQuest.entry().children().remove(quest.entry());
+                    selectedQuest.entry().dependants().remove(quest.entry());
                     quest.entry().dependencies().remove(quest.entry());
                 } else {
-                    if (!quest.entry().children().contains(selectedQuest.entry())) {
+                    if (!quest.entry().dependants().contains(selectedQuest.entry())) {
                         if (quest.quest().dependencies().add(selectedQuest.id())) {
-                            selectedQuest.entry().children().add(quest.entry());
+                            selectedQuest.entry().dependants().add(quest.entry());
                             quest.entry().dependencies().add(selectedQuest.entry());
                         }
                     }

--- a/common/src/main/java/earth/terrarium/heracles/client/widgets/modals/AddDependencyModal.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/widgets/modals/AddDependencyModal.java
@@ -58,7 +58,7 @@ public class AddDependencyModal extends BaseModal {
         if (entry != null) {
             ClientQuests.QuestEntry entry = ClientQuests.get(value).orElse(null);
             if (entry != null) {
-                entry.children().add(this.entry);
+                entry.dependants().add(this.entry);
                 this.entry.dependencies().add(entry);
                 this.dependencies.add(entry.value());
                 this.entry.value().dependencies().add(value);
@@ -108,7 +108,7 @@ public class AddDependencyModal extends BaseModal {
                     this.dependencies.remove(dependency);
                     for (ClientQuests.QuestEntry questEntry : ClientQuests.entries()) {
                         if (questEntry.value().equals(dependency)) {
-                            questEntry.children().remove(this.entry);
+                            questEntry.dependants().remove(this.entry);
                             this.entry.dependencies().remove(questEntry);
                             this.entry.value().dependencies().remove(questEntry.key());
                             this.callback.run();

--- a/common/src/main/java/earth/terrarium/heracles/client/widgets/modals/AddDependencyModal.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/widgets/modals/AddDependencyModal.java
@@ -58,7 +58,7 @@ public class AddDependencyModal extends BaseModal {
         if (entry != null) {
             ClientQuests.QuestEntry entry = ClientQuests.get(value).orElse(null);
             if (entry != null) {
-                entry.dependants().add(this.entry);
+                entry.dependents().add(this.entry);
                 this.entry.dependencies().add(entry);
                 this.dependencies.add(entry.value());
                 this.entry.value().dependencies().add(value);
@@ -108,7 +108,7 @@ public class AddDependencyModal extends BaseModal {
                     this.dependencies.remove(dependency);
                     for (ClientQuests.QuestEntry questEntry : ClientQuests.entries()) {
                         if (questEntry.value().equals(dependency)) {
-                            questEntry.dependants().remove(this.entry);
+                            questEntry.dependents().remove(this.entry);
                             this.entry.dependencies().remove(questEntry);
                             this.entry.value().dependencies().remove(questEntry.key());
                             this.callback.run();


### PR DESCRIPTION
- Renamed 'children' to be 'dependents' to be more consistent with dependencies and less confusing
- Previously, `addEntry` would create an entry and add it as a dependent in all cases, which is bad if the entry is already created causing excessive memory usage and duplicates in the list. This optimizes it to only do work if the result is not already computed.
