### PR TITLE
fix casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can then add our mod as a dependency:
 ```gradle
 dependencies {
     <--- Other dependencies here --->
-    modImplementation "earth.terrarium.heracles:heracles-${modloader}-${mc_version}:${heracles_version}"
+    modImplementation "earth.terrarium.heracles:Heracles-${modloader}-${mc_version}:${heracles_version}"
 }
 ```
 


### PR DESCRIPTION
I tried adding Heracles as a dependency in my mod environment, but it constantly failed. The solution was to write `Heracles` instead of `heracles`. You can change this on your own if you want, I just was too lazy to create an issue and describe what's wrong.
Maybe I had found out before but couldn't find anything in the maven by browsing.