### PR TITLE
Add config to disable book/barrier registration, add null checks

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/client/toasts/QuestTutorialToast.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/toasts/QuestTutorialToast.java
@@ -8,7 +8,10 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.toasts.Toast;
 import net.minecraft.client.gui.components.toasts.ToastComponent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.Items;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
 
 public class QuestTutorialToast implements Toast {
     private static final Component TITLE_TEXT = Component.translatable("quest.heracles.tutorial.title");
@@ -31,7 +34,7 @@ public class QuestTutorialToast implements Toast {
             false
         );
 
-        graphics.renderFakeItem(ModItems.QUEST_BOOK.get().getDefaultInstance(), 8, 8);
+        graphics.renderFakeItem(Objects.requireNonNullElse(ModItems.QUEST_BOOK.get(), Items.KNOWLEDGE_BOOK).getDefaultInstance(), 8, 8);
 
         return DisplayConfig.showTutorial && QuestTutorial.toast == this ? Visibility.SHOW : Visibility.HIDE;
     }

--- a/common/src/main/java/earth/terrarium/heracles/common/commands/ModCommands.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/commands/ModCommands.java
@@ -2,9 +2,11 @@ package earth.terrarium.heracles.common.commands;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 import earth.terrarium.heracles.Heracles;
 import earth.terrarium.heracles.api.tasks.defaults.DummyTask;
+import earth.terrarium.heracles.common.handlers.CommonConfig;
 import earth.terrarium.heracles.common.handlers.progress.QuestProgressHandler;
 import earth.terrarium.heracles.common.handlers.quests.QuestHandler;
 import net.minecraft.commands.CommandSourceStack;
@@ -26,24 +28,25 @@ public class ModCommands {
     };
 
     public static void init(CommandDispatcher<CommandSourceStack> dispatcher) {
-        dispatcher.register(Commands.literal(Heracles.MOD_ID)
-            .then(PinCommand.pin())
-            .then(ResetCommand.reset())
-            .then(ResetCommand.resetAll())
-            .then(CompleteCommand.complete())
-            .then(BarrierCommand.barrier())
-            .then(Commands.literal("dummy")
-                .requires(source -> source.hasPermission(2))
-                .then(Commands.argument("id", StringArgumentType.string())
-                    .executes(context -> {
-                        CommandSourceStack source = context.getSource();
-                        ServerPlayer player = source.getPlayerOrException();
-                        String quest = StringArgumentType.getString(context, "id");
-                        QuestProgressHandler.getProgress(source.getServer(), player.getUUID()).testAndProgressTaskType(player, quest, DummyTask.TYPE);
-                        return 1;
-                    })
-                )
+        LiteralArgumentBuilder<CommandSourceStack> root = Commands.literal(Heracles.MOD_ID);
+        root.then(PinCommand.pin());
+        root.then(ResetCommand.reset());
+        root.then(ResetCommand.resetAll());
+        root.then(CompleteCommand.complete());
+        root.then(Commands.literal("dummy")
+            .requires(source -> source.hasPermission(2))
+            .then(Commands.argument("id", StringArgumentType.string())
+                .executes(context -> {
+                    CommandSourceStack source = context.getSource();
+                    ServerPlayer player = source.getPlayerOrException();
+                    String quest = StringArgumentType.getString(context, "id");
+                    QuestProgressHandler.getProgress(source.getServer(), player.getUUID()).testAndProgressTaskType(player, quest, DummyTask.TYPE);
+                    return 1;
+                })
             )
         );
+        if (CommonConfig.registerUtilities) root.then(BarrierCommand.barrier());
+
+        dispatcher.register(root);
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/common/handlers/CommonConfig.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/handlers/CommonConfig.java
@@ -1,0 +1,51 @@
+package earth.terrarium.heracles.common.handlers;
+
+import com.google.gson.JsonObject;
+import com.teamresourceful.resourcefullib.common.lib.Constants;
+import earth.terrarium.heracles.Heracles;
+import net.minecraft.util.GsonHelper;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+public class CommonConfig {
+
+    private static final String CONFIG_FILE = "heracles_common_options.json";
+
+    private static Path lastPath;
+
+    public static boolean registerBook = true;
+    public static boolean registerUtilities = true;
+
+    public static void load(Path path) {
+        CommonConfig.lastPath = path;
+        File displayFile = path.resolve(CONFIG_FILE).toFile();
+        try {
+            if (displayFile.exists()) {
+                String configString = FileUtils.readFileToString(displayFile, StandardCharsets.UTF_8);
+                JsonObject configObject = Constants.PRETTY_GSON.fromJson(configString, JsonObject.class);
+                registerBook = GsonHelper.getAsBoolean(configObject, "registerBook", true);
+                registerUtilities = GsonHelper.getAsBoolean(configObject, "registerUtilities", true);
+            } else {
+                save();
+            }
+        } catch (Exception e) {
+            Heracles.LOGGER.error("Error parsing {}:", CONFIG_FILE, e);
+        }
+    }
+
+    public static void save() {
+        if (lastPath == null) return;
+        File displayFile = lastPath.resolve(CONFIG_FILE).toFile();
+        JsonObject displayObject = new JsonObject();
+        displayObject.addProperty("registerBook", registerBook);
+        displayObject.addProperty("registerUtilities", registerUtilities);
+        try {
+            FileUtils.write(displayFile, Constants.PRETTY_GSON.toJson(displayObject), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            Heracles.LOGGER.error("Error saving {}:", CONFIG_FILE, e);
+        }
+    }
+}

--- a/common/src/main/java/earth/terrarium/heracles/common/regisitries/ModBlocks.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/regisitries/ModBlocks.java
@@ -6,10 +6,12 @@ import com.teamresourceful.resourcefullib.common.registry.ResourcefulRegistry;
 import earth.terrarium.heracles.Heracles;
 import earth.terrarium.heracles.common.blocks.BarrierBlock;
 import earth.terrarium.heracles.common.blocks.BarrierBlockEntity;
+import earth.terrarium.heracles.common.handlers.CommonConfig;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntityType;
+import org.jetbrains.annotations.Nullable;
 
 public class ModBlocks {
 
@@ -17,12 +19,12 @@ public class ModBlocks {
     public static final ResourcefulRegistry<Block> BLOCKS = ResourcefulRegistries.create(BuiltInRegistries.BLOCK, Heracles.MOD_ID);
 
 
-    public static final RegistryEntry<Block> BARRIER_BLOCK = BLOCKS.register(
+    public static final @Nullable RegistryEntry<Block> BARRIER_BLOCK = !CommonConfig.registerUtilities ? null : BLOCKS.register(
         "barrier",
         () -> new BarrierBlock(Block.Properties.copy(Blocks.BARRIER))
     );
 
-    public static final RegistryEntry<BlockEntityType<BarrierBlockEntity>> BARRIER_BLOCK_ENTITY = BLOCK_ENTITIES.register(
+    public static final @Nullable RegistryEntry<BlockEntityType<BarrierBlockEntity>> BARRIER_BLOCK_ENTITY = BARRIER_BLOCK == null ? null : BLOCK_ENTITIES.register(
         "barrier",
         () -> BlockEntityType.Builder.of(BarrierBlockEntity::new, ModBlocks.BARRIER_BLOCK.get()).build(null)
     );

--- a/common/src/main/java/earth/terrarium/heracles/common/regisitries/ModItems.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/regisitries/ModItems.java
@@ -3,16 +3,18 @@ package earth.terrarium.heracles.common.regisitries;
 import com.teamresourceful.resourcefullib.common.registry.ItemLikeResourcefulRegistry;
 import com.teamresourceful.resourcefullib.common.registry.ItemLikeResourcefulRegistry.Entry;
 import earth.terrarium.heracles.Heracles;
+import earth.terrarium.heracles.common.handlers.CommonConfig;
 import earth.terrarium.heracles.common.items.BarrierItem;
 import earth.terrarium.heracles.common.items.QuestBookItem;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.item.Item;
+import org.jetbrains.annotations.Nullable;
 
 public class ModItems {
 
     public static final ItemLikeResourcefulRegistry<Item> ITEMS = new ItemLikeResourcefulRegistry<>(BuiltInRegistries.ITEM, Heracles.MOD_ID);
 
-    public static final Entry<Item> QUEST_BOOK = ITEMS.register("quest_book", () -> new QuestBookItem(new Item.Properties()));
-    public static final Entry<Item> BARRIER = ITEMS.register("barrier", () -> new BarrierItem(ModBlocks.BARRIER_BLOCK.get(), new Item.Properties()));
+    public static final @Nullable Entry<Item> QUEST_BOOK = !CommonConfig.registerBook ? null : ITEMS.register("quest_book", () -> new QuestBookItem(new Item.Properties()));
+    public static final @Nullable Entry<Item> BARRIER = ModBlocks.BARRIER_BLOCK == null ? null : ITEMS.register("barrier", () -> new BarrierItem(ModBlocks.BARRIER_BLOCK.get(), new Item.Properties()));
 
 }

--- a/common/src/main/java/earth/terrarium/heracles/mixins/client/ClientLevelMixin.java
+++ b/common/src/main/java/earth/terrarium/heracles/mixins/client/ClientLevelMixin.java
@@ -24,6 +24,7 @@ public class ClientLevelMixin {
         if (this.minecraft.player == null) return;
         if (this.minecraft.gameMode == null) return;
         if (this.minecraft.gameMode.getPlayerMode() != GameType.CREATIVE) return;
+        if (ModItems.BARRIER == null) return;
         ItemStack itemStack = this.minecraft.player.getMainHandItem();
         if (itemStack.is(ModItems.BARRIER.get())) {
             cir.setReturnValue(ModBlocks.BARRIER_BLOCK.get());

--- a/fabric/src/main/java/earth/terrarium/heracles/fabric/HeraclesFabric.java
+++ b/fabric/src/main/java/earth/terrarium/heracles/fabric/HeraclesFabric.java
@@ -6,6 +6,7 @@ import earth.terrarium.heracles.api.tasks.defaults.EntityInteractTask;
 import earth.terrarium.heracles.api.tasks.defaults.ItemInteractTask;
 import earth.terrarium.heracles.api.tasks.defaults.KillEntityQuestTask;
 import earth.terrarium.heracles.common.commands.ModCommands;
+import earth.terrarium.heracles.common.handlers.CommonConfig;
 import earth.terrarium.heracles.common.handlers.progress.QuestProgressHandler;
 import earth.terrarium.heracles.common.utils.PlatformSettings;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
@@ -24,6 +25,7 @@ import net.minecraft.world.item.ItemStack;
 public class HeraclesFabric {
     public static void init() {
         Heracles.setConfigPath(FabricLoader.getInstance().getConfigDir());
+        CommonConfig.load(FabricLoader.getInstance().getGameDir());
         Heracles.init(new PlatformSettings(true));
 
         CommandRegistrationCallback.EVENT.register((dispatcher, context, env) -> ModCommands.init(dispatcher));

--- a/forge/src/main/java/earth/terrarium/heracles/forge/HeraclesForge.java
+++ b/forge/src/main/java/earth/terrarium/heracles/forge/HeraclesForge.java
@@ -3,6 +3,7 @@ package earth.terrarium.heracles.forge;
 import earth.terrarium.heracles.Heracles;
 import earth.terrarium.heracles.api.tasks.defaults.*;
 import earth.terrarium.heracles.common.commands.ModCommands;
+import earth.terrarium.heracles.common.handlers.CommonConfig;
 import earth.terrarium.heracles.common.handlers.progress.QuestProgressHandler;
 import earth.terrarium.heracles.common.handlers.progress.QuestsProgress;
 import earth.terrarium.heracles.common.utils.PlatformSettings;
@@ -29,6 +30,7 @@ public class HeraclesForge {
 
     public HeraclesForge() {
         Heracles.setConfigPath(FMLPaths.CONFIGDIR.get());
+        CommonConfig.load(FMLPaths.GAMEDIR.get());
         Heracles.init(new PlatformSettings(false));
 
         MinecraftForge.EVENT_BUS.addListener(HeraclesForge::onServerStarting);


### PR DESCRIPTION
would close #235 as completed.

Adds a `heracles-common-options.json` that allows disabling the registration of the quest book and barrier.

The primary purpose for this is modpack and server flexibility.
Configured right, this lets vanilla clients connect to a heracles server, as well as completely remove quest barriers from `/fill` and the book from `/give`.
FTB struggles from a lot of feature bloat - and we consider its set of knicknacks in the registry to  be part of that, so if we continue to use heracles, we'll use it with these configs off - merged or hardfile forked.

Cases Tested:
- On Client / On Server: Normal operation
- Off Client / Off Server: No blocks / items, items do not show up in /give, blocks to not show up in /fill.
- On Client / Off Server: Connects fine. Recipe viewers will show book/barrier but their give commands naturally fail.
- Off Client / On Server: Registry mismatch
- Vanilla Client / Off Server: Works. No GUI or toasts obviously - could set up server-based UI in this config.
- Vanilla Client / On Server: Unsupported vanilla client.
- Vanilla Client / 1.1.13 Server: Unsupported vanilla client.
- Vanilla Client / 1.1.12 Server: Unsupported vanilla client.

Limitations:
- Off Client / On Server case causes a mismatch.
- (#208) Configs are a mess so the added one is a mess
- Code has to think about whether blocks/items are null (could be optional to flag this better)
