### PR TITLE
fix: Text setting length is limited to 32 chars

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/api/client/settings/base/TextSetting.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/client/settings/base/TextSetting.java
@@ -33,8 +33,8 @@ public record TextSetting<O>(Predicate<String> charFilter, Predicate<String> fil
     public ValidatingEditBox createWidget(int width, O value) {
         ValidatingEditBox box = new ValidatingEditBox(Minecraft.getInstance().font, 0, 0, width, 11, CommonComponents.EMPTY, filter);
         box.setFilter(charFilter);
-        box.setValue(decoder.apply(value));
         box.setMaxLength(32767);
+        box.setValue(decoder.apply(value));
         return box;
     }
 


### PR DESCRIPTION
We should be setting the max length limit before we set the value, otherwise the text will be shrunk in the EditBox#setValue method.

```java
    public void setValue(String text) {
        if (this.filter.test(text)) {
            if (text.length() > this.maxLength) {
                this.value = text.substring(0, this.maxLength);
            } else {
                this.value = text;
            }

            this.moveCursorToEnd();
            this.setHighlightPos(this.cursorPos);
            this.onValueChange(text);
        }
    }
```
Originally we call setValue first, and only then follow it with setMaxLength, the text is already shrunk at that point.
This PR prioritizes setting the max length first to avoid this issue.