### PR TITLE
Respect dependencies' display status when recursively checking visibility for "Parents Visible"

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quests/QuestsWidget.java
@@ -174,7 +174,7 @@ public class QuestsWidget extends BaseWidget {
                 return false;
             }
             for (var dependency : quest.dependencies()) {
-                if (shouldHide(statuses, dependency, QuestDisplayStatus.DEPENDENCIES_VISIBLE)) {
+                if (shouldHide(statuses, dependency, dependency.value().settings().hiddenUntil())) {
                     return true;
                 }
             }


### PR DESCRIPTION
Fixes #259 

> [!NOTE]
>
> This piece of code exists in another place on the [feat/ui-refactor](https://github.com/terrarium-earth/Heracles/tree/feat/ui-refactor) branch:
> https://github.com/terrarium-earth/Heracles/blob/7b1748ebcbf2f7369f0972fb6dcac65d8626aa25/common/src/main/java/earth/terrarium/heracles/client/components/quests/QuestsWidget.java#L128