### PR TITLE
Fixed structure tasks

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/api/client/settings/base/RegistryValueSetting.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/client/settings/base/RegistryValueSetting.java
@@ -3,6 +3,7 @@ package earth.terrarium.heracles.api.client.settings.base;
 import com.mojang.datafixers.util.Either;
 import earth.terrarium.heracles.Heracles;
 import earth.terrarium.heracles.api.client.settings.Setting;
+import earth.terrarium.heracles.client.handlers.ClientStructureDisplays;
 import earth.terrarium.heracles.client.widgets.boxes.AutocompleteEditBox;
 import earth.terrarium.heracles.common.utils.RegistryValue;
 import net.minecraft.Optionull;
@@ -38,14 +39,26 @@ public record RegistryValueSetting<T>(
             (text, item) -> item.contains(text) && !item.equals(text), Function.identity(), s -> {});
         box.setMaxLength(Short.MAX_VALUE);
         List<String> suggestions = new ArrayList<>();
+        
         var registry = Heracles.getRegistryAccess().registry(key).orElse(null);
-        if (registry == null) {
-            return box;
-        }
-        registry.getTagNames().map(tag -> "#" + tag.location()).forEach(suggestions::add);
-        registry.keySet().stream().map(ResourceLocation::toString).forEach(suggestions::add);
+        if (registry != null) {
+            // Use registry data when available
+            registry.getTagNames().map(tag -> "#" + tag.location()).forEach(suggestions::add);
+            registry.keySet().stream().map(ResourceLocation::toString).forEach(suggestions::add);
+        } else if (key.location().equals(Registries.STRUCTURE.location()) && ClientStructureDisplays.hasStructureData()) {
+            // Fallback to cached structure data for structures
+            ClientStructureDisplays.getStructureTags().stream()
+                .map(tag -> "#" + tag.toString())
+                .forEach(suggestions::add);
+            ClientStructureDisplays.getStructures().stream()
+                .map(ResourceLocation::toString)
+                .forEach(suggestions::add);
+        } 
+        
+        // Sort suggestions alphabetically for better user experience
+        suggestions.sort(String.CASE_INSENSITIVE_ORDER);
+        
         box.setSuggestions(suggestions);
-
         box.setValue(Optionull.mapOrDefault(value, RegistryValue::toRegistryString, ""));
         return box;
     }
@@ -56,14 +69,36 @@ public record RegistryValueSetting<T>(
             ResourceLocation id = ResourceLocation.tryParse(widget.getValue().substring(1));
             return id == null ? null : new RegistryValue<>(Either.right(TagKey.create(key, id)));
         }
-        var registry = Heracles.getRegistryAccess().registry(key).orElse(null);
-        if (registry == null) {
+        
+        ResourceLocation id = ResourceLocation.tryParse(widget.getValue());
+        if (id == null) {
             return null;
         }
-        return Optionull.map(
-            ResourceLocation.tryParse(widget.getValue()), id -> registry.getHolder(ResourceKey.create(key, id))
+        
+        var registry = Heracles.getRegistryAccess().registry(key).orElse(null);
+        if (registry != null) {
+            return registry.getHolder(ResourceKey.create(key, id))
                 .map(RegistryValue::new)
-                .orElse(null)
-        );
+                .orElse(null);
+        } else if (key.location().equals(Registries.STRUCTURE.location()) && ClientStructureDisplays.hasStructureData()) {
+            // Fallback for structures when registry is unavailable
+            if (ClientStructureDisplays.getStructures().contains(id)) {
+                // Try to create a standalone holder, but handle exceptions gracefully
+                try {
+                    ResourceKey<T> resourceKey = ResourceKey.create(key, id);
+                    @SuppressWarnings("unchecked")
+                    net.minecraft.core.Holder<T> holder = (net.minecraft.core.Holder<T>) 
+                        net.minecraft.core.Holder.Reference.createStandAlone(
+                            Heracles.getRegistryAccess().lookupOrThrow(key), resourceKey);
+                    return new RegistryValue<>(Either.left(holder));
+                } catch (Exception e) {
+                    // If holder creation fails, fall through to return null
+                    // This is still better than crashing
+                }
+            }
+        }
+        // If we reach here, the registry is unavailable and we couldn't create a proper holder
+        // Return null which will cause fallback to default, but this is better than crashing
+        return null;
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/client/settings/base/StructureStringSetting.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/client/settings/base/StructureStringSetting.java
@@ -1,0 +1,79 @@
+package earth.terrarium.heracles.api.client.settings.base;
+
+import earth.terrarium.heracles.Heracles;
+import earth.terrarium.heracles.api.client.settings.Setting;
+import earth.terrarium.heracles.client.handlers.ClientStructureDisplays;
+import earth.terrarium.heracles.client.widgets.boxes.AutocompleteEditBox;
+import net.minecraft.Optionull;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.levelgen.structure.Structure;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * A setting that handles structure input as plain strings while providing autocomplete functionality.
+ * This setting stores and returns plain strings, but uses the same autocomplete data as RegistryValueSetting
+ * from both registry access and ClientStructureDisplays.
+ */
+public record StructureStringSetting() implements Setting<String, AutocompleteEditBox<String>> {
+
+    @Override
+    public AutocompleteEditBox<String> createWidget(int width, String value) {
+        AutocompleteEditBox<String> box = new AutocompleteEditBox<>(Minecraft.getInstance().font, 0, 0, width, 11,
+            (text, item) -> item.contains(text) && !item.equals(text), Function.identity(), s -> {});
+        box.setMaxLength(Short.MAX_VALUE);
+        List<String> suggestions = new ArrayList<>();
+        
+        var registry = Heracles.getRegistryAccess().registry(Registries.STRUCTURE).orElse(null);
+        if (registry != null) {
+            // Use registry data when available
+            registry.getTagNames().map(tag -> "#" + tag.location()).forEach(suggestions::add);
+            registry.keySet().stream().map(ResourceLocation::toString).forEach(suggestions::add);
+        } else if (ClientStructureDisplays.hasStructureData()) {
+            // Fallback to cached structure data for structures
+            ClientStructureDisplays.getStructureTags().stream()
+                .map(tag -> "#" + tag.toString())
+                .forEach(suggestions::add);
+            ClientStructureDisplays.getStructures().stream()
+                .map(ResourceLocation::toString)
+                .forEach(suggestions::add);
+        }
+        
+        // Sort suggestions alphabetically for better user experience
+        suggestions.sort(String.CASE_INSENSITIVE_ORDER);
+        
+        box.setSuggestions(suggestions);
+        box.setValue(Optionull.mapOrDefault(value, Function.identity(), ""));
+        return box;
+    }
+
+    @Override
+    public String getValue(AutocompleteEditBox<String> widget) {
+        String value = widget.getValue();
+        if (value == null || value.trim().isEmpty()) {
+            return "";
+        }
+        
+        // Validate the input format but return the string as-is
+        if (value.startsWith("#")) {
+            // Tag format: #namespace:tag_name
+            ResourceLocation id = ResourceLocation.tryParse(value.substring(1));
+            if (id == null) {
+                return ""; // Invalid tag format
+            }
+        } else {
+            // Structure format: namespace:structure_name
+            ResourceLocation id = ResourceLocation.tryParse(value);
+            if (id == null) {
+                return ""; // Invalid structure format
+            }
+        }
+        
+        // Return the validated string as-is
+        return value.trim();
+    }
+}

--- a/common/src/main/java/earth/terrarium/heracles/api/client/settings/tasks/StructureTaskSettings.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/client/settings/tasks/StructureTaskSettings.java
@@ -1,10 +1,17 @@
 package earth.terrarium.heracles.api.client.settings.tasks;
 
+import com.mojang.datafixers.util.Either;
 import earth.terrarium.heracles.api.client.settings.CustomizableQuestElementSettings;
 import earth.terrarium.heracles.api.client.settings.SettingInitializer;
 import earth.terrarium.heracles.api.client.settings.base.RegistryValueSetting;
+import earth.terrarium.heracles.api.client.settings.base.StructureStringSetting;
 import earth.terrarium.heracles.api.tasks.defaults.StructureTask;
+import earth.terrarium.heracles.common.utils.RegistryValue;
 import net.minecraft.Optionull;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.levelgen.structure.Structure;
 import org.jetbrains.annotations.Nullable;
 
 public class StructureTaskSettings implements SettingInitializer<StructureTask>, CustomizableQuestElementSettings<StructureTask> {
@@ -14,7 +21,7 @@ public class StructureTaskSettings implements SettingInitializer<StructureTask>,
     @Override
     public CreationData create(@Nullable StructureTask object) {
         CreationData settings = CustomizableQuestElementSettings.super.create(object);
-        settings.put("structure", RegistryValueSetting.STRUCTURE, Optionull.map(object, StructureTask::structures));
+        settings.put("structure", new StructureStringSetting(), getDefaultStructureString(object));
         return settings;
     }
 
@@ -24,7 +31,25 @@ public class StructureTaskSettings implements SettingInitializer<StructureTask>,
             id,
             title,
             icon,
-            data.get("structure", RegistryValueSetting.STRUCTURE).orElse(Optionull.mapOrDefault(object, StructureTask::structures, null))
+            null, // Keep structures as null for new string-based approach
+            data.get("structure", new StructureStringSetting()).orElse(getDefaultStructureString(object))
         ));
+    }
+
+    private static String getDefaultStructureString(StructureTask object) {
+        if (object != null) {
+            // Convert existing RegistryValue to string if available
+            if (object.structureString() != null) {
+                return object.structureString();
+            } else if (object.structures() != null) {
+                return object.structures().toRegistryString();
+            }
+        }
+        return "#minecraft:village"; // Default fallback
+    }
+
+    private static RegistryValue<Structure> getDefaultStructure(StructureTask object) {
+        return Optionull.mapOrDefault(object, StructureTask::structures, 
+            new RegistryValue<>(Either.right(TagKey.create(Registries.STRUCTURE, new ResourceLocation("minecraft", "village")))));
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/client/display/TaskTitleFormatters.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/client/display/TaskTitleFormatters.java
@@ -23,7 +23,28 @@ public class TaskTitleFormatters {
         TaskTitleFormatter.register(AdvancementTask.TYPE, (task) -> Component.translatable(toTranslationKey(task, task.advancements().size() == 1)));
         TaskTitleFormatter.register(ChangedDimensionTask.TYPE, (task) -> Component.translatable(toTranslationKey(task, true)));
         TaskTitleFormatter.register(RecipeTask.TYPE, (task) -> Component.translatable(toTranslationKey(task, task.recipes().size() == 1), Optionull.firstOrDefault(task.titles(), CommonComponents.EMPTY)));
-        TaskTitleFormatter.register(StructureTask.TYPE, (task) -> Component.translatable(toTranslationKey(task, true), task.structures().getDisplayName((id, structure) -> Component.translatableWithFallback(Util.makeDescriptionId("structure", id), id.toString()))));
+        TaskTitleFormatter.register(StructureTask.TYPE, (task) -> {
+            Component displayName;
+            if (task.structures() != null) {
+                // Use existing RegistryValue approach for backward compatibility
+                displayName = task.structures().getDisplayName((id, structure) -> Component.translatableWithFallback(Util.makeDescriptionId("structure", id), id.toString()));
+            } else if (task.structureString() != null && !task.structureString().isEmpty()) {
+                // Use string-based approach - create display name from string
+                String structureString = task.structureString();
+                if (structureString.startsWith("#")) {
+                    // Tag format: #namespace:tag_name
+                    String tagName = structureString.substring(1);
+                    displayName = Component.translatableWithFallback("tag.structure." + tagName.replace(":", "."), tagName);
+                } else {
+                    // Structure format: namespace:structure_name
+                    displayName = Component.translatableWithFallback(Util.makeDescriptionId("structure", new ResourceLocation(structureString)), structureString);
+                }
+            } else {
+                // Fallback for cases where both are null/empty
+                displayName = Component.literal("Unknown Structure");
+            }
+            return Component.translatable(toTranslationKey(task, true), displayName);
+        });
         TaskTitleFormatter.register(BiomeTask.TYPE, (task) -> Component.translatable(toTranslationKey(task, true), task.biomes().getDisplayName((id, structure) -> Component.translatableWithFallback(Util.makeDescriptionId("biome", id), id.toString()))));
         TaskTitleFormatter.register(BlockInteractTask.TYPE, (task) -> Component.translatable(toTranslationKey(task, true), task.block().getDisplayName(Block::getName)));
         TaskTitleFormatter.register(ItemInteractTask.TYPE, (task) -> Component.translatable(toTranslationKey(task, true), task.item().getDisplayName(Item::getDescription)));

--- a/common/src/main/java/earth/terrarium/heracles/api/tasks/defaults/StructureTask.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/tasks/defaults/StructureTask.java
@@ -11,17 +11,21 @@ import earth.terrarium.heracles.api.tasks.QuestTask;
 import earth.terrarium.heracles.api.tasks.QuestTaskType;
 import earth.terrarium.heracles.api.tasks.storage.defaults.BooleanTaskStorage;
 import earth.terrarium.heracles.common.utils.RegistryValue;
+import earth.terrarium.heracles.common.utils.StructureResolver;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.NumericTag;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.levelgen.structure.Structure;
+import com.mojang.datafixers.util.Either;
 
 import java.util.Collection;
 
 public record StructureTask(
-    String id, String title, QuestIcon<?> icon, RegistryValue<Structure> structures
+    String id, String title, QuestIcon<?> icon, RegistryValue<Structure> structures, String structureString
 ) implements QuestTask<Collection<Structure>, NumericTag, StructureTask>, CustomizableQuestElement {
 
     public static final QuestTaskType<StructureTask> TYPE = new Type();
@@ -29,11 +33,25 @@ public record StructureTask(
     @Override
     public NumericTag test(QuestTaskType<?> type, NumericTag progress, Collection<Structure> input) {
         final RegistryAccess access = Heracles.getRegistryAccess();
-        final Registry<Structure> registry = access.registry(Registries.STRUCTURE).orElse(null);
+        final Registry<Structure> registry = access != null ? access.registry(Registries.STRUCTURE).orElse(null) : null;
+        
         if (registry != null) {
-            for (Structure structure : input) {
-                if (structures().is(registry.wrapAsHolder(structure))) {
-                    return storage().of(progress, true);
+            // Try existing RegistryValue first
+            if (structures() != null) {
+                for (Structure structure : input) {
+                    if (structures().is(registry.wrapAsHolder(structure))) {
+                        return storage().of(progress, true);
+                    }
+                }
+            } else if (structureString() != null && !structureString().isEmpty()) {
+                // Resolve string to RegistryValue and test
+                RegistryValue<Structure> resolved = StructureResolver.resolveStructureString(structureString(), access);
+                if (resolved != null) {
+                    for (Structure structure : input) {
+                        if (resolved.is(registry.wrapAsHolder(structure))) {
+                            return storage().of(progress, true);
+                        }
+                    }
                 }
             }
         }
@@ -68,8 +86,10 @@ public record StructureTask(
                 RecordCodecBuilder.point(id),
                 Codec.STRING.optionalFieldOf("title", "").forGetter(StructureTask::title),
                 QuestIcons.CODEC.optionalFieldOf("icon", ItemQuestIcon.AIR).forGetter(StructureTask::icon),
-                RegistryValue.codec(Registries.STRUCTURE).fieldOf("structures").forGetter(StructureTask::structures)
-            ).apply(instance, StructureTask::new));
+                RegistryValue.codec(Registries.STRUCTURE).optionalFieldOf("structures").forGetter(task -> java.util.Optional.ofNullable(task.structures())),
+                Codec.STRING.optionalFieldOf("structureString", "").forGetter(StructureTask::structureString)
+            ).apply(instance, (taskId, title, icon, structures, structureString) -> 
+                new StructureTask(taskId, title, icon, structures.orElse(null), structureString)));
         }
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/client/handlers/ClientStructureDisplays.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/handlers/ClientStructureDisplays.java
@@ -1,0 +1,36 @@
+package earth.terrarium.heracles.client.handlers;
+
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ClientStructureDisplays {
+
+    private static final Set<ResourceLocation> STRUCTURES = new HashSet<>();
+    private static final Set<ResourceLocation> STRUCTURE_TAGS = new HashSet<>();
+
+    public static void update(Set<ResourceLocation> structures, Set<ResourceLocation> structureTags) {
+        STRUCTURES.clear();
+        STRUCTURES.addAll(structures);
+        STRUCTURE_TAGS.clear();
+        STRUCTURE_TAGS.addAll(structureTags);
+    }
+
+    public static Set<ResourceLocation> getStructures() {
+        return new HashSet<>(STRUCTURES);
+    }
+
+    public static Set<ResourceLocation> getStructureTags() {
+        return new HashSet<>(STRUCTURE_TAGS);
+    }
+
+    public static boolean hasStructureData() {
+        return !STRUCTURES.isEmpty() || !STRUCTURE_TAGS.isEmpty();
+    }
+
+    public static void clear() {
+        STRUCTURES.clear();
+        STRUCTURE_TAGS.clear();
+    }
+}

--- a/common/src/main/java/earth/terrarium/heracles/common/network/NetworkHandler.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/network/NetworkHandler.java
@@ -3,6 +3,7 @@ package earth.terrarium.heracles.common.network;
 import com.teamresourceful.resourcefullib.common.network.NetworkChannel;
 import earth.terrarium.heracles.Heracles;
 import earth.terrarium.heracles.common.network.packets.*;
+import earth.terrarium.heracles.common.network.packets.ClientboundStructureDisplayPacket;
 import earth.terrarium.heracles.common.network.packets.groups.CreateGroupPacket;
 import earth.terrarium.heracles.common.network.packets.groups.DeleteGroupPacket;
 import earth.terrarium.heracles.common.network.packets.groups.OpenGroupPacket;
@@ -37,6 +38,7 @@ public class NetworkHandler {
         CHANNEL.register(QuestUnlockedPacket.TYPE);
         CHANNEL.register(ClientboundAdvancementDisplayPacket.TYPE);
         CHANNEL.register(ClientboundLootTablesDisplayPacket.TYPE);
+        CHANNEL.register(ClientboundStructureDisplayPacket.TYPE);
 
         CHANNEL.register(OpenGroupPacket.TYPE);
         CHANNEL.register(OpenQuestPacket.TYPE);

--- a/common/src/main/java/earth/terrarium/heracles/common/network/packets/ClientboundStructureDisplayPacket.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/network/packets/ClientboundStructureDisplayPacket.java
@@ -1,0 +1,77 @@
+package earth.terrarium.heracles.common.network.packets;
+
+import com.teamresourceful.resourcefullib.common.network.Packet;
+import com.teamresourceful.resourcefullib.common.network.base.ClientboundPacketType;
+import com.teamresourceful.resourcefullib.common.network.base.PacketType;
+import earth.terrarium.heracles.Heracles;
+import earth.terrarium.heracles.client.handlers.ClientStructureDisplays;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.levelgen.structure.Structure;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record ClientboundStructureDisplayPacket(
+    Set<ResourceLocation> structures,
+    Set<ResourceLocation> structureTags
+) implements Packet<ClientboundStructureDisplayPacket> {
+
+    public static final ClientboundPacketType<ClientboundStructureDisplayPacket> TYPE = new Type();
+
+    public ClientboundStructureDisplayPacket(MinecraftServer server) {
+        this(
+            server.registryAccess()
+                .registry(Registries.STRUCTURE)
+                .map(registry -> registry.keySet())
+                .orElse(Set.of()),
+            server.registryAccess()
+                .registry(Registries.STRUCTURE)
+                .map(registry -> registry.getTagNames()
+                    .map(TagKey::location)
+                    .collect(Collectors.toSet()))
+                .orElse(Set.of())
+        );
+    }
+
+    @Override
+    public PacketType<ClientboundStructureDisplayPacket> type() {
+        return TYPE;
+    }
+
+    private static class Type implements ClientboundPacketType<ClientboundStructureDisplayPacket> {
+        @Override
+        public Class<ClientboundStructureDisplayPacket> type() {
+            return ClientboundStructureDisplayPacket.class;
+        }
+
+        @Override
+        public ResourceLocation id() {
+            return new ResourceLocation(Heracles.MOD_ID, "structure_display");
+        }
+
+        @Override
+        public void encode(ClientboundStructureDisplayPacket message, FriendlyByteBuf buffer) {
+            buffer.writeCollection(message.structures, FriendlyByteBuf::writeResourceLocation);
+            buffer.writeCollection(message.structureTags, FriendlyByteBuf::writeResourceLocation);
+        }
+
+        @Override
+        public ClientboundStructureDisplayPacket decode(FriendlyByteBuf buffer) {
+            return new ClientboundStructureDisplayPacket(
+                Set.copyOf(buffer.readCollection(HashSet::new, FriendlyByteBuf::readResourceLocation)),
+                Set.copyOf(buffer.readCollection(HashSet::new, FriendlyByteBuf::readResourceLocation))
+            );
+        }
+
+        @Override
+        public Runnable handle(ClientboundStructureDisplayPacket message) {
+            return () -> ClientStructureDisplays.update(message.structures(), message.structureTags());
+        }
+    }
+}

--- a/common/src/main/java/earth/terrarium/heracles/common/utils/StructureResolver.java
+++ b/common/src/main/java/earth/terrarium/heracles/common/utils/StructureResolver.java
@@ -1,0 +1,85 @@
+package earth.terrarium.heracles.common.utils;
+
+import com.mojang.datafixers.util.Either;
+import earth.terrarium.heracles.Heracles;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.levelgen.structure.Structure;
+
+/**
+ * Utility class for resolving string structure names to registry entries in a context-aware manner.
+ * Only performs registry resolution when needed (server-side or single-player scenarios).
+ */
+public class StructureResolver {
+
+    /**
+     * Resolves a structure string to a RegistryValue<Structure> when registry access is available.
+     * Handles both direct structure names and tag references (prefixed with #).
+     * 
+     * @param structureString The structure string to resolve (e.g., "minecraft:village" or "#minecraft:village")
+     * @param access The registry access to use for resolution
+     * @return A RegistryValue<Structure> if resolution is successful, null otherwise
+     */
+    public static RegistryValue<Structure> resolveStructureString(String structureString, RegistryAccess access) {
+        // Check if we have registry access (server-side or single-player)
+        if (access == null) {
+            return null; // Client-side fallback
+        }
+        
+        if (structureString == null || structureString.trim().isEmpty()) {
+            return null;
+        }
+        
+        String trimmed = structureString.trim();
+        Registry<Structure> registry = access.registry(Registries.STRUCTURE).orElse(null);
+        
+        if (registry == null) {
+            return null; // Registry not available
+        }
+        
+        if (trimmed.startsWith("#")) {
+            // Tag format: #namespace:tag_name
+            ResourceLocation id = ResourceLocation.tryParse(trimmed.substring(1));
+            if (id != null) {
+                return new RegistryValue<>(Either.right(TagKey.create(Registries.STRUCTURE, id)));
+            }
+        } else {
+            // Structure format: namespace:structure_name
+            ResourceLocation id = ResourceLocation.tryParse(trimmed);
+            if (id != null) {
+                ResourceKey<Structure> resourceKey = ResourceKey.create(Registries.STRUCTURE, id);
+                return registry.getHolder(resourceKey)
+                    .map(RegistryValue::new)
+                    .orElse(null);
+            }
+        }
+        
+        return null;
+    }
+    
+    /**
+     * Determines if we're in a context that requires registry validation.
+     * This checks if we're on the server-side or in single-player mode where registry access is available.
+     * 
+     * @return true if registry resolution should be performed, false for client-only scenarios
+     */
+    public static boolean needsRegistryResolution() {
+        // Determine if we're in a context that requires registry validation
+        // (server-side or single-player)
+        return Heracles.getRegistryAccess() != null;
+    }
+    
+    /**
+     * Convenience method that uses the current registry access from Heracles.
+     * 
+     * @param structureString The structure string to resolve
+     * @return A RegistryValue<Structure> if resolution is successful, null otherwise
+     */
+    public static RegistryValue<Structure> resolveStructureString(String structureString) {
+        return resolveStructureString(structureString, Heracles.getRegistryAccess());
+    }
+}

--- a/common/src/main/java/earth/terrarium/heracles/mixins/client/MinecraftClientMixin.java
+++ b/common/src/main/java/earth/terrarium/heracles/mixins/client/MinecraftClientMixin.java
@@ -1,0 +1,20 @@
+package earth.terrarium.heracles.mixins.client;
+
+import earth.terrarium.heracles.client.handlers.ClientStructureDisplays;
+import net.minecraft.client.Minecraft;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Minecraft.class)
+public class MinecraftClientMixin {
+
+    @Inject(method = "clearLevel()V", at = @At("HEAD"))
+    private void heracles$onDisconnect(CallbackInfo ci) {
+        // Clear cached structure data when disconnecting from server
+        // This ensures clean state when switching between servers or going to single player
+        System.out.println("[DEBUG_LOG] Client disconnecting - clearing cached structure data");
+        ClientStructureDisplays.clear();
+    }
+}

--- a/common/src/main/java/earth/terrarium/heracles/mixins/common/PlayerListMixin.java
+++ b/common/src/main/java/earth/terrarium/heracles/mixins/common/PlayerListMixin.java
@@ -4,6 +4,7 @@ import earth.terrarium.heracles.common.handlers.syncing.QuestSyncer;
 import earth.terrarium.heracles.common.network.NetworkHandler;
 import earth.terrarium.heracles.common.network.packets.ClientboundAdvancementDisplayPacket;
 import earth.terrarium.heracles.common.network.packets.ClientboundLootTablesDisplayPacket;
+import earth.terrarium.heracles.common.network.packets.ClientboundStructureDisplayPacket;
 import net.minecraft.network.Connection;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
@@ -42,6 +43,10 @@ public class PlayerListMixin {
             new ClientboundLootTablesDisplayPacket(this.server),
             player
         );
+        NetworkHandler.CHANNEL.sendToPlayer(
+            new ClientboundStructureDisplayPacket(this.server),
+            player
+        );
     }
 
     @Inject(
@@ -56,6 +61,10 @@ public class PlayerListMixin {
         );
         NetworkHandler.CHANNEL.sendToPlayers(
             new ClientboundLootTablesDisplayPacket(this.server),
+            this.players
+        );
+        NetworkHandler.CHANNEL.sendToPlayers(
+            new ClientboundStructureDisplayPacket(this.server),
             this.players
         );
     }

--- a/common/src/main/resources/heracles-common.mixins.json
+++ b/common/src/main/resources/heracles-common.mixins.json
@@ -16,6 +16,7 @@
         "client.AbstractButtonMixin",
         "client.ClientLevelMixin",
         "client.InternalKeyPressedScreen",
+        "client.MinecraftClientMixin",
         "client.ScreenMixin"
     ],
     "injectors": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ group=earth.terrarium.heracles
 minecraftVersion=1.20.1
 parchmentVersion=2023.07.02
 
-resourcefulLibVersion=2.1.23
+resourcefulLibVersion=2.1.29
 reiVersion=12.0.630
 emiVersion=1.1.2
 jeiVersion=15.2.0.27


### PR DESCRIPTION
Basically, this commit just fixes structure tasks to actually be usable and just good on client and server.
More specifically it fixes #202 

Autocomplete is there and it's alphabetized, it works in single-player and uses the actual registry in single-player, or in multiplayer it provides a cached registry of all the structures to the client, because if that's not done The client simply doesn't have access to the registry for the structures, This also accounts for situations where the server has data packs or mods installed for structure generation that were not required on the client, so aren't on there. This is especially useful for making quests on live multiplayer servers.

One other notable change that I made was bumping resourceful lib

I would really appreciate any feedback you have on the commit, and if there's any changes I can make, I'm definitely willing to. I just don't have much spare time, so I don't want to commit another five hours or something.




I've included an AI summary to this commit, and I want to be transparent that AI was used to assist me to make these changes.  I wouldn't typically publicly publish this kind of AI work, but I thought it might be of actual value since it works so well for me.

I am going to leave edits open to maintainers in case you guys want to just quickly make changes without checking with me, I don't mind. And I want to be transparent that I didn't test this on Forge, However, the changes I made shouldn't be platform-dependent. I did test it with Fabric Client and Server and Fabric Singleplayer.




-
=============================================================================
This pull request introduces a new string-based approach for handling structure-related settings and tasks, improving flexibility and fallback mechanisms when registry data is unavailable. Key changes include the addition of a new `StructureStringSetting` class, updates to accommodate both `RegistryValue` and string-based structures, and a client-side caching mechanism for structure data.

### Structure handling improvements:

* **New `StructureStringSetting` class**: Introduced to handle structure input as plain strings with autocomplete functionality, supporting both registry-based and cached data. 
* **Fallback for missing registry data**: Updated `RegistryValueSetting` to use cached structure data from `ClientStructureDisplays` when registry data is unavailable. This ensures better resilience.

### Task-related updates:

* **Enhancements to `StructureTask`**: Added support for a new `structureString` field in addition to the existing `structures` field, allowing tasks to work with both registry-based and string-based structures. 
* **Improved task title formatting**: Updated `TaskTitleFormatters` to generate display names for string-based structures, ensuring compatibility with the new approach. 

### Client-side caching:

* **New `ClientStructureDisplays` class**: Implemented to cache structure and structure tag data on the client, enabling fallback mechanisms when registry access is unavailable. 
* **Network integration**: Registered a new packet, `ClientboundStructureDisplayPacket`, to synchronize structure data between the server and client. 

These changes collectively enhance the flexibility and robustness of structure handling in the system, while maintaining backward compatibility.