### PR TITLE
Allow editing source and destination dimensions of `ChangedDimensionTask` to null in GUI

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/api/client/settings/base/OptionalRegistryKeySetting.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/client/settings/base/OptionalRegistryKeySetting.java
@@ -3,6 +3,7 @@ package earth.terrarium.heracles.api.client.settings.base;
 import earth.terrarium.heracles.Heracles;
 import earth.terrarium.heracles.api.client.settings.Setting;
 import earth.terrarium.heracles.client.widgets.boxes.AutocompleteEditBox;
+import earth.terrarium.heracles.client.widgets.boxes.OptionalAutocompleteEditBox;
 import net.minecraft.Optionull;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.Registry;
@@ -10,40 +11,43 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-public record RegistryKeySetting<T>(
+public record OptionalRegistryKeySetting<T>(
     ResourceKey<? extends Registry<T>> key
-) implements Setting<ResourceKey<T>, AutocompleteEditBox<String>> {
+) implements Setting<@Nullable ResourceKey<T>, OptionalAutocompleteEditBox<String>> {
 
-    @Deprecated
-    public static final RegistryKeySetting<Level> DIMENSION = new RegistryKeySetting<>(Registries.DIMENSION);
+    public static final OptionalRegistryKeySetting<Level> DIMENSION = new OptionalRegistryKeySetting<>(Registries.DIMENSION);
 
     @Override
-    public AutocompleteEditBox<String> createWidget(int width, ResourceKey<T> value) {
-        AutocompleteEditBox<String> box = new AutocompleteEditBox<>(Minecraft.getInstance().font, 0, 0, width, 11,
+    public OptionalAutocompleteEditBox<String> createWidget(int width, ResourceKey<T> value) {
+        OptionalAutocompleteEditBox<String> optionalBox = new OptionalAutocompleteEditBox<>(Minecraft.getInstance().font, 0, 0, width, 11,
             (text, item) -> item.contains(text) && !item.equals(text), Function.identity(), s -> {});
+        AutocompleteEditBox<String> box = optionalBox.getEditBox();
         box.setMaxLength(Short.MAX_VALUE);
         List<String> suggestions = new ArrayList<>();
         var registry = Heracles.getRegistryAccess().registry(key).orElse(null);
         if (registry == null) {
-            return box;
+            return optionalBox;
         }
         registry.keySet().stream().map(ResourceLocation::toString).forEach(suggestions::add);
         box.setSuggestions(suggestions);
 
-        ResourceLocation id = Optionull.map(value, ResourceKey::location);
-        box.setValue(id == null ? "" : id.toString());
-        return box;
+        String id = Optionull.map(value, key -> key.location().toString());
+        optionalBox.setValue(id);
+        return optionalBox;
     }
 
     @Override
-    public ResourceKey<T> getValue(AutocompleteEditBox<String> widget) {
-        ResourceLocation id = ResourceLocation.tryParse(widget.getValue());
+    public ResourceKey<T> getValue(OptionalAutocompleteEditBox<String> widget) {
+        String value = widget.value();
+        if (value == null) return null;
+        ResourceLocation id = ResourceLocation.tryParse(value);
         return Optional.ofNullable(id)
             .map(ignored -> ResourceKey.create(key, id))
             .orElse(null);

--- a/common/src/main/java/earth/terrarium/heracles/api/client/settings/base/OptionalRegistryKeySetting.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/client/settings/base/OptionalRegistryKeySetting.java
@@ -2,7 +2,6 @@ package earth.terrarium.heracles.api.client.settings.base;
 
 import earth.terrarium.heracles.Heracles;
 import earth.terrarium.heracles.api.client.settings.Setting;
-import earth.terrarium.heracles.client.widgets.boxes.AutocompleteEditBox;
 import earth.terrarium.heracles.client.widgets.boxes.OptionalAutocompleteEditBox;
 import net.minecraft.Optionull;
 import net.minecraft.client.Minecraft;

--- a/common/src/main/java/earth/terrarium/heracles/api/client/settings/base/OptionalRegistryKeySetting.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/client/settings/base/OptionalRegistryKeySetting.java
@@ -26,26 +26,25 @@ public record OptionalRegistryKeySetting<T>(
 
     @Override
     public OptionalAutocompleteEditBox<String> createWidget(int width, ResourceKey<T> value) {
-        OptionalAutocompleteEditBox<String> optionalBox = new OptionalAutocompleteEditBox<>(Minecraft.getInstance().font, 0, 0, width, 11,
+        OptionalAutocompleteEditBox<String> box = new OptionalAutocompleteEditBox<>(Minecraft.getInstance().font, 0, 0, width, 11,
             (text, item) -> item.contains(text) && !item.equals(text), Function.identity(), s -> {});
-        AutocompleteEditBox<String> box = optionalBox.getEditBox();
         box.setMaxLength(Short.MAX_VALUE);
         List<String> suggestions = new ArrayList<>();
         var registry = Heracles.getRegistryAccess().registry(key).orElse(null);
         if (registry == null) {
-            return optionalBox;
+            return box;
         }
         registry.keySet().stream().map(ResourceLocation::toString).forEach(suggestions::add);
         box.setSuggestions(suggestions);
 
         String id = Optionull.map(value, key -> key.location().toString());
-        optionalBox.setValue(id);
-        return optionalBox;
+        box.setValue(id);
+        return box;
     }
 
     @Override
     public ResourceKey<T> getValue(OptionalAutocompleteEditBox<String> widget) {
-        String value = widget.value();
+        String value = widget.nullableValue();
         if (value == null) return null;
         ResourceLocation id = ResourceLocation.tryParse(value);
         return Optional.ofNullable(id)

--- a/common/src/main/java/earth/terrarium/heracles/api/client/settings/tasks/DimensionTaskSettings.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/client/settings/tasks/DimensionTaskSettings.java
@@ -27,8 +27,8 @@ public class DimensionTaskSettings implements SettingInitializer<ChangedDimensio
             id,
             title,
             icon,
-            data.get("from", OptionalRegistryKeySetting.DIMENSION).orElse(Optionull.map(object, ChangedDimensionTask::from)),
-            data.get("to", OptionalRegistryKeySetting.DIMENSION).orElse(Optionull.map(object, ChangedDimensionTask::to))
+            data.get("from", OptionalRegistryKeySetting.DIMENSION).orElse(null),
+            data.get("to", OptionalRegistryKeySetting.DIMENSION).orElse(null)
         ));
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/api/client/settings/tasks/DimensionTaskSettings.java
+++ b/common/src/main/java/earth/terrarium/heracles/api/client/settings/tasks/DimensionTaskSettings.java
@@ -2,6 +2,7 @@ package earth.terrarium.heracles.api.client.settings.tasks;
 
 import earth.terrarium.heracles.api.client.settings.CustomizableQuestElementSettings;
 import earth.terrarium.heracles.api.client.settings.SettingInitializer;
+import earth.terrarium.heracles.api.client.settings.base.OptionalRegistryKeySetting;
 import earth.terrarium.heracles.api.client.settings.base.RegistryKeySetting;
 import earth.terrarium.heracles.api.tasks.defaults.ChangedDimensionTask;
 import net.minecraft.Optionull;
@@ -15,8 +16,8 @@ public class DimensionTaskSettings implements SettingInitializer<ChangedDimensio
     @Override
     public CreationData create(@Nullable ChangedDimensionTask object) {
         CreationData settings = CustomizableQuestElementSettings.super.create(object);
-        settings.put("from", RegistryKeySetting.DIMENSION, Optionull.mapOrDefault(object, ChangedDimensionTask::from, Level.OVERWORLD));
-        settings.put("to", RegistryKeySetting.DIMENSION, Optionull.mapOrDefault(object, ChangedDimensionTask::to, Level.OVERWORLD));
+        settings.put("from", OptionalRegistryKeySetting.DIMENSION, Optionull.mapOrDefault(object, ChangedDimensionTask::from, Level.OVERWORLD));
+        settings.put("to", OptionalRegistryKeySetting.DIMENSION, Optionull.mapOrDefault(object, ChangedDimensionTask::to, Level.OVERWORLD));
         return settings;
     }
 
@@ -26,8 +27,8 @@ public class DimensionTaskSettings implements SettingInitializer<ChangedDimensio
             id,
             title,
             icon,
-            data.get("from", RegistryKeySetting.DIMENSION).orElse(Optionull.map(object, ChangedDimensionTask::from)),
-            data.get("to", RegistryKeySetting.DIMENSION).orElse(Optionull.map(object, ChangedDimensionTask::to))
+            data.get("from", OptionalRegistryKeySetting.DIMENSION).orElse(Optionull.map(object, ChangedDimensionTask::from)),
+            data.get("to", OptionalRegistryKeySetting.DIMENSION).orElse(Optionull.map(object, ChangedDimensionTask::to))
         ));
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/client/widgets/boxes/AutocompleteEditBox.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/widgets/boxes/AutocompleteEditBox.java
@@ -48,8 +48,8 @@ public class AutocompleteEditBox<T> extends EditBox {
     }
 
     @Override
-    public void renderWidget(GuiGraphics graphics, int i, int j, float f) {
-        super.renderWidget(graphics, i, j, f);
+    public void renderWidget(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+        super.renderWidget(graphics, mouseX, mouseY, partialTick);
         if (!isFocused()) return;
         int x = this.getX();
         int y = this.getY() + this.getHeight() + 1;

--- a/common/src/main/java/earth/terrarium/heracles/client/widgets/boxes/OptionalAutocompleteEditBox.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/widgets/boxes/OptionalAutocompleteEditBox.java
@@ -1,13 +1,9 @@
 package earth.terrarium.heracles.client.widgets.boxes;
 
-import net.minecraft.client.gui.ComponentPath;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Checkbox;
-import net.minecraft.client.gui.navigation.FocusNavigationEvent;
-import net.minecraft.client.gui.navigation.ScreenRectangle;
 import net.minecraft.network.chat.CommonComponents;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.function.BiPredicate;

--- a/common/src/main/java/earth/terrarium/heracles/client/widgets/boxes/OptionalAutocompleteEditBox.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/widgets/boxes/OptionalAutocompleteEditBox.java
@@ -4,9 +4,6 @@ import net.minecraft.client.gui.ComponentPath;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Checkbox;
-import net.minecraft.client.gui.components.Renderable;
-import net.minecraft.client.gui.components.events.GuiEventListener;
-import net.minecraft.client.gui.layouts.LinearLayout;
 import net.minecraft.client.gui.navigation.FocusNavigationEvent;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
 import net.minecraft.network.chat.CommonComponents;
@@ -17,21 +14,17 @@ import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class OptionalAutocompleteEditBox<T> extends LinearLayout implements Renderable, GuiEventListener {
+public class OptionalAutocompleteEditBox<T> extends AutocompleteEditBox<T> {
     private static final int CHECKBOX_WIDTH = 24;
     private final Checkbox checkbox;
-    private final AutocompleteEditBox<T> editBox;
 
     public OptionalAutocompleteEditBox(Font font, int x, int y, int width, int height, BiPredicate<String, T> filter, Function<T, String> mapper, Consumer<String> onEnter) {
-        super(x, y, width, height, Orientation.HORIZONTAL);
+        super(font, x + CHECKBOX_WIDTH, y, width - CHECKBOX_WIDTH, height, filter, mapper, onEnter);
         this.checkbox = new Checkbox(x, y, CHECKBOX_WIDTH, height, CommonComponents.EMPTY, false, false);
-        this.editBox = new AutocompleteEditBox<>(font, x + CHECKBOX_WIDTH, y, width - CHECKBOX_WIDTH, height, filter, mapper, onEnter);
-        this.addChild(this.checkbox);
-        this.addChild(this.editBox);
     }
 
-    public @Nullable String value() {
-        return checkbox.selected() ? editBox.getValue() : null;
+    public @Nullable T nullableValue() {
+        return checkbox.selected() ? this.value() : null;
     }
 
     public void setValue(@Nullable String value) {
@@ -39,88 +32,55 @@ public class OptionalAutocompleteEditBox<T> extends LinearLayout implements Rend
             if (checkbox.selected()) checkbox.onPress();
         } else {
             if (!checkbox.selected()) checkbox.onPress();
-            this.editBox.setValue(value);
+            super.setValue(value);
         }
+        this.updateEditBoxEditability();
     }
 
-    public AutocompleteEditBox<T> getEditBox() {
-        return this.editBox;
-    }
-
-    @Override
-    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
-        this.checkbox.render(guiGraphics, mouseX, mouseY, partialTick);
-        this.editBox.render(guiGraphics, mouseX, mouseY, partialTick);
+    private void updateEditBoxEditability() {
+        this.setEditable(checkbox.selected());
     }
 
     @Override
-    public void mouseMoved(double mouseX, double mouseY) {
-        this.checkbox.mouseMoved(mouseX, mouseY);
-        this.editBox.mouseMoved(mouseX, mouseY);
+    public void renderWidget(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+        this.checkbox.render(graphics, mouseX, mouseY, partialTick);
+        super.renderWidget(graphics, mouseX, mouseY, partialTick);
     }
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        return this.checkbox.mouseClicked(mouseX, mouseY, button) | this.editBox.mouseClicked(mouseX, mouseY, button);
-    }
-
-    @Override
-    public boolean mouseReleased(double mouseX, double mouseY, int button) {
-        return this.checkbox.mouseReleased(mouseX, mouseY, button) | this.editBox.mouseReleased(mouseX, mouseY, button);
-    }
-
-    @Override
-    public boolean mouseDragged(double mouseX, double mouseY, int button, double dragX, double dragY) {
-        return this.checkbox.mouseDragged(mouseX, mouseY, button, dragX, dragY) | this.editBox.mouseDragged(mouseX, mouseY, button, dragX, dragY);
-    }
-
-    @Override
-    public boolean mouseScrolled(double mouseX, double mouseY, double delta) {
-        return this.checkbox.mouseScrolled(mouseX, mouseY, delta) | this.editBox.mouseScrolled(mouseX, mouseY, delta);
-    }
-
-    @Override
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        return this.checkbox.keyPressed(keyCode, scanCode, modifiers) | this.checkbox.keyPressed(keyCode, scanCode, modifiers);
-    }
-
-    @Override
-    public boolean keyReleased(int keyCode, int scanCode, int modifiers) {
-        return this.checkbox.keyReleased(keyCode, scanCode, modifiers) | this.checkbox.keyReleased(keyCode, scanCode, modifiers);
-    }
-
-    @Override
-    public boolean charTyped(char codePoint, int modifiers) {
-        return this.checkbox.charTyped(codePoint, modifiers) | this.editBox.charTyped(codePoint, modifiers);
-    }
-
-    @Override
-    public @Nullable ComponentPath nextFocusPath(FocusNavigationEvent event) {
-        return this.editBox.nextFocusPath(event);
+        return this.checkbox.mouseClicked(mouseX, mouseY, button) | super.mouseClicked(mouseX, mouseY, button);
     }
 
     @Override
     public boolean isMouseOver(double mouseX, double mouseY) {
-        return this.checkbox.isMouseOver(mouseX, mouseY) | this.editBox.isMouseOver(mouseX, mouseY);
+        return super.isMouseOver(mouseX, mouseY) || this.checkbox.isMouseOver(mouseX, mouseY);
     }
 
     @Override
-    public void setFocused(boolean focused) {
-        this.editBox.setFocused(focused);
+    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+        return this.checkbox.keyPressed(keyCode, scanCode, modifiers) | super.keyPressed(keyCode, scanCode, modifiers);
     }
 
     @Override
-    public boolean isFocused() {
-        return this.editBox.isFocused();
+    public boolean charTyped(char codePoint, int modifiers) {
+        return this.checkbox.charTyped(codePoint, modifiers) | super.charTyped(codePoint, modifiers);
     }
 
     @Override
-    public @Nullable ComponentPath getCurrentFocusPath() {
-        return this.editBox.getCurrentFocusPath();
+    public void setX(int x) {
+        this.checkbox.setX(x);
+        super.setX(x + CHECKBOX_WIDTH);
     }
 
     @Override
-    public @NotNull ScreenRectangle getRectangle() {
-        return super.getRectangle();
+    public void setY(int y) {
+        this.checkbox.setY(y);
+        super.setY(y);
+    }
+
+    @Override
+    public void setWidth(int width) {
+        super.setWidth(width - CHECKBOX_WIDTH);
     }
 }

--- a/common/src/main/java/earth/terrarium/heracles/client/widgets/boxes/OptionalAutocompleteEditBox.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/widgets/boxes/OptionalAutocompleteEditBox.java
@@ -49,7 +49,9 @@ public class OptionalAutocompleteEditBox<T> extends AutocompleteEditBox<T> {
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        return this.checkbox.mouseClicked(mouseX, mouseY, button) | super.mouseClicked(mouseX, mouseY, button);
+        boolean value = this.checkbox.mouseClicked(mouseX, mouseY, button) | super.mouseClicked(mouseX, mouseY, button);
+        this.updateEditBoxEditability();
+        return value;
     }
 
     @Override
@@ -59,7 +61,9 @@ public class OptionalAutocompleteEditBox<T> extends AutocompleteEditBox<T> {
 
     @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        return this.checkbox.keyPressed(keyCode, scanCode, modifiers) | super.keyPressed(keyCode, scanCode, modifiers);
+        boolean value = this.checkbox.keyPressed(keyCode, scanCode, modifiers) | super.keyPressed(keyCode, scanCode, modifiers);
+        this.updateEditBoxEditability();
+        return value;
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/heracles/client/widgets/boxes/OptionalAutocompleteEditBox.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/widgets/boxes/OptionalAutocompleteEditBox.java
@@ -1,0 +1,126 @@
+package earth.terrarium.heracles.client.widgets.boxes;
+
+import net.minecraft.client.gui.ComponentPath;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Checkbox;
+import net.minecraft.client.gui.components.Renderable;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.layouts.LinearLayout;
+import net.minecraft.client.gui.navigation.FocusNavigationEvent;
+import net.minecraft.client.gui.navigation.ScreenRectangle;
+import net.minecraft.network.chat.CommonComponents;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class OptionalAutocompleteEditBox<T> extends LinearLayout implements Renderable, GuiEventListener {
+    private static final int CHECKBOX_WIDTH = 24;
+    private final Checkbox checkbox;
+    private final AutocompleteEditBox<T> editBox;
+
+    public OptionalAutocompleteEditBox(Font font, int x, int y, int width, int height, BiPredicate<String, T> filter, Function<T, String> mapper, Consumer<String> onEnter) {
+        super(x, y, width, height, Orientation.HORIZONTAL);
+        this.checkbox = new Checkbox(x, y, CHECKBOX_WIDTH, height, CommonComponents.EMPTY, false, false);
+        this.editBox = new AutocompleteEditBox<>(font, x + CHECKBOX_WIDTH, y, width - CHECKBOX_WIDTH, height, filter, mapper, onEnter);
+        this.addChild(this.checkbox);
+        this.addChild(this.editBox);
+    }
+
+    public @Nullable String value() {
+        return checkbox.selected() ? editBox.getValue() : null;
+    }
+
+    public void setValue(@Nullable String value) {
+        if (value == null) {
+            if (checkbox.selected()) checkbox.onPress();
+        } else {
+            if (!checkbox.selected()) checkbox.onPress();
+            this.editBox.setValue(value);
+        }
+    }
+
+    public AutocompleteEditBox<T> getEditBox() {
+        return this.editBox;
+    }
+
+    @Override
+    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        this.checkbox.render(guiGraphics, mouseX, mouseY, partialTick);
+        this.editBox.render(guiGraphics, mouseX, mouseY, partialTick);
+    }
+
+    @Override
+    public void mouseMoved(double mouseX, double mouseY) {
+        this.checkbox.mouseMoved(mouseX, mouseY);
+        this.editBox.mouseMoved(mouseX, mouseY);
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        return this.checkbox.mouseClicked(mouseX, mouseY, button) | this.editBox.mouseClicked(mouseX, mouseY, button);
+    }
+
+    @Override
+    public boolean mouseReleased(double mouseX, double mouseY, int button) {
+        return this.checkbox.mouseReleased(mouseX, mouseY, button) | this.editBox.mouseReleased(mouseX, mouseY, button);
+    }
+
+    @Override
+    public boolean mouseDragged(double mouseX, double mouseY, int button, double dragX, double dragY) {
+        return this.checkbox.mouseDragged(mouseX, mouseY, button, dragX, dragY) | this.editBox.mouseDragged(mouseX, mouseY, button, dragX, dragY);
+    }
+
+    @Override
+    public boolean mouseScrolled(double mouseX, double mouseY, double delta) {
+        return this.checkbox.mouseScrolled(mouseX, mouseY, delta) | this.editBox.mouseScrolled(mouseX, mouseY, delta);
+    }
+
+    @Override
+    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+        return this.checkbox.keyPressed(keyCode, scanCode, modifiers) | this.checkbox.keyPressed(keyCode, scanCode, modifiers);
+    }
+
+    @Override
+    public boolean keyReleased(int keyCode, int scanCode, int modifiers) {
+        return this.checkbox.keyReleased(keyCode, scanCode, modifiers) | this.checkbox.keyReleased(keyCode, scanCode, modifiers);
+    }
+
+    @Override
+    public boolean charTyped(char codePoint, int modifiers) {
+        return this.checkbox.charTyped(codePoint, modifiers) | this.editBox.charTyped(codePoint, modifiers);
+    }
+
+    @Override
+    public @Nullable ComponentPath nextFocusPath(FocusNavigationEvent event) {
+        return this.editBox.nextFocusPath(event);
+    }
+
+    @Override
+    public boolean isMouseOver(double mouseX, double mouseY) {
+        return this.checkbox.isMouseOver(mouseX, mouseY) | this.editBox.isMouseOver(mouseX, mouseY);
+    }
+
+    @Override
+    public void setFocused(boolean focused) {
+        this.editBox.setFocused(focused);
+    }
+
+    @Override
+    public boolean isFocused() {
+        return this.editBox.isFocused();
+    }
+
+    @Override
+    public @Nullable ComponentPath getCurrentFocusPath() {
+        return this.editBox.getCurrentFocusPath();
+    }
+
+    @Override
+    public @NotNull ScreenRectangle getRectangle() {
+        return super.getRectangle();
+    }
+}

--- a/common/src/main/resources/assets/heracles_tasks/lang/en_us.json
+++ b/common/src/main/resources/assets/heracles_tasks/lang/en_us.json
@@ -104,6 +104,7 @@
     "task.heracles.changed_dimension": "\uD83C\uDF0A Changed Dimension",
     "task.heracles.changed_dimension.title.singular": "Travel between dimensions",
     "task.heracles.changed_dimension.desc.singular": "From %s To %s",
+    "task.heracles.changed_dimension.desc.dim.any": "Any Dimension",
     "setting.heracles.changed_dimension.title": "Title Override:",
     "setting.heracles.changed_dimension.icon": "Icon Override:",
     "setting.heracles.changed_dimension.from": "From:",


### PR DESCRIPTION
Closes #268.

To-do:

* Make tab navigation work correctly
* Checkbox is too big for the task editor – maybe we should make a smaller version