### PR TITLE
Add links to quest descriptions

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/client/screens/quest/MarkdownParser.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/screens/quest/MarkdownParser.java
@@ -1,7 +1,9 @@
 package earth.terrarium.heracles.client.screens.quest;
 
 import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.network.chat.MutableComponent;
 
 import java.util.ArrayList;
@@ -15,6 +17,8 @@ public class MarkdownParser {
 
     private static final Pattern COLOR_PATTERN = Pattern.compile("([^\\\\]|^)&&([0-9a-fA-Fk-oK-OrR])");
     private static final Pattern AMPERSANDS_NOT_ENTITY_PATTERN = Pattern.compile("&(?!([a-z0-9]+|#[0-9]{1,6}|#x[0-9a-fA-F]{1,6});)");
+    private static final Pattern MARKDOWN_LINK_PATTERN = Pattern.compile("\\[([^]]+)]\\(([^)]+)\\)");
+
     private static final Map<String, String> CHAR_TO_ENTITY = Map.of(
         "<", "&#60;",
         ">", "&#62;",
@@ -98,25 +102,57 @@ public class MarkdownParser {
         }
 
         if (indexes.values().stream().mapToInt(i -> i).max().orElse(-1) == -1) {
-            return Component.literal(builder.toString());
+            return withLinks(builder.toString());
         }
 
         //smallest non 0 value
         int smallest = indexes.values().stream().filter(i -> i != -1).mapToInt(i -> i).min().orElse(-1);
         Formatting formatting = indexes.entrySet().stream().filter(e -> e.getValue() == smallest).map(Map.Entry::getKey).findFirst().orElse(null);
         if (formatting == null) {
-            return Component.literal(builder.toString());
+            return withLinks(builder.toString());
         }
-        component.append(Component.literal(builder.substring(0, smallest)));
+        component.append(withLinks(builder.substring(0, smallest)));
         builder.delete(0, smallest + formatting.symbol.length());
         int end = builder.indexOf(formatting.symbol);
         if (end == -1) {
-            return Component.literal(text);
+            return withLinks(text);
         }
         component.append(parseTextToComponent(builder.substring(0, end)).withStyle(formatting.formatting));
         builder.delete(0, end + formatting.symbol.length());
         component.append(parseTextToComponent(builder.toString()));
         return component;
+    }
+
+    /**
+     * Takes in a string and converts it to a Component, basically {@link Component#literal}, but also parses any Markdown
+     * links in the form [link](url) into valid click events.
+     */
+    private static MutableComponent withLinks(String text) {
+        Matcher matcher = MARKDOWN_LINK_PATTERN.matcher(text);
+
+        MutableComponent result = Component.empty();
+
+        int lastEnd = 0;
+        while (matcher.find()) {
+            // Add text before this link
+            result.append(Component.literal(text.substring(lastEnd, matcher.start())));
+
+            String label = matcher.group(1);
+            String link = matcher.group(2);
+
+            ClickEvent event = new ClickEvent(ClickEvent.Action.OPEN_URL, link);
+            HoverEvent hover = new HoverEvent(HoverEvent.Action.SHOW_TEXT, Component.literal(link).withStyle(ChatFormatting.GRAY));
+
+            // Add the link
+            result.append(Component.literal(label).withStyle(style -> style.withClickEvent(event).withHoverEvent(hover)));
+
+            lastEnd = matcher.end();
+        }
+
+        // Add remaining text after the last link
+        result.append(Component.literal(text.substring(lastEnd)));
+
+        return result;
     }
 
     private enum Formatting {


### PR DESCRIPTION
This PR adds the ability to use markdown links \[link\]\(url\) to quest descriptions. They respect all formatting applied around them, and prompt the user when clicked like a normal minecraft click event.

<img width="1032" height="340" alt="image" src="https://github.com/user-attachments/assets/48a77f80-4f66-4817-a45c-d2e5c65f65e3" />
<img width="922" height="419" alt="image" src="https://github.com/user-attachments/assets/f3e6dee2-2527-4ef7-af57-7b44b75c19a6" />
<img width="646" height="276" alt="image" src="https://github.com/user-attachments/assets/0b6ab8ef-bfdc-4a56-bd65-1204c55d2eaa" />

I will see about porting this feature to the 1.21.1 branch.