### PR TITLE
Fix links in descriptions (1.21.1)

### DIFF
--- a/common/src/main/java/earth/terrarium/heracles/client/components/quest/editor/parser/MarkdownParagraphParser.java
+++ b/common/src/main/java/earth/terrarium/heracles/client/components/quest/editor/parser/MarkdownParagraphParser.java
@@ -57,7 +57,7 @@ public class MarkdownParagraphParser {
     }
 
     private static String replaceLinks(String text) {
-        return replace(LINK_PATTERN, text, "<link href=\"$2\">$1</link>");
+        return replace(LINK_PATTERN, text, "<a href=\"$2\">$1</a>");
     }
 
     private static String replaceFormatting(String text) {


### PR DESCRIPTION
Fix the use of markdown links in quest descriptions. It was already implemented on 1.21.1, but didn't work, because hermes only parses `<a>` into a `LinkElement` and we were using a `<link>`.

As a side note: at some point hermes might want to implement the minecraft "are you sure" screen for links. Its a bit jarring for users to instantly open the link when they're used to the warning.